### PR TITLE
feat: expanded rule report data

### DIFF
--- a/src/createRule.ts
+++ b/src/createRule.ts
@@ -3,17 +3,19 @@ import { AnyOptionalSchema } from "./types/shapes.js";
 
 export function createRule<
 	const About extends RuleAbout,
-	const Message extends string,
->(definition: RuleDefinition<About, Message, undefined>): typeof definition;
+	const MessageId extends string,
+>(definition: RuleDefinition<About, MessageId, undefined>): typeof definition;
 export function createRule<
 	const About extends RuleAbout,
-	const Message extends string,
+	const MessageId extends string,
 	const OptionsSchema extends AnyOptionalSchema,
->(definition: RuleDefinition<About, Message, OptionsSchema>): typeof definition;
+>(
+	definition: RuleDefinition<About, MessageId, OptionsSchema>,
+): typeof definition;
 export function createRule<
 	const About extends RuleAbout,
-	const Message extends string,
+	const MessageId extends string,
 	const OptionsSchema extends AnyOptionalSchema | undefined,
->(definition: RuleDefinition<About, Message, OptionsSchema>) {
+>(definition: RuleDefinition<About, MessageId, OptionsSchema>) {
 	return definition;
 }

--- a/src/plugins/createPlugin.test-d.ts
+++ b/src/plugins/createPlugin.test-d.ts
@@ -4,11 +4,13 @@ import z from "zod";
 import { createRule } from "../createRule.js";
 import { createPlugin } from "./createPlugin.js";
 
+const stubMessages = { "": { primary: "", secondary: [], suggestions: [] } };
+
 const ruleStandalone = createRule({
 	about: {
 		id: "standalone",
 	},
-	messages: { "": "" },
+	messages: stubMessages,
 	setup: vi.fn(),
 });
 
@@ -16,7 +18,7 @@ const ruleWithOptionalOption = createRule({
 	about: {
 		id: "withOptionalOption",
 	},
-	messages: { "": "" },
+	messages: stubMessages,
 	options: {
 		value: z.string().optional(),
 	},

--- a/src/plugins/createPlugin.test.ts
+++ b/src/plugins/createPlugin.test.ts
@@ -4,12 +4,14 @@ import z from "zod";
 import { createRule } from "../createRule.js";
 import { createPlugin } from "./createPlugin.js";
 
+const stubMessages = { "": { primary: "", secondary: [], suggestions: [] } };
+
 const ruleStandalone = createRule({
 	about: {
 		id: "standalone",
 		preset: "first",
 	},
-	messages: { "": "" },
+	messages: stubMessages,
 	setup: vi.fn(),
 });
 
@@ -18,7 +20,7 @@ const ruleWithOptionalOption = createRule({
 		id: "withOptionalOption",
 		preset: "second",
 	},
-	messages: { "": "" },
+	messages: stubMessages,
 	options: {
 		value: z.string().optional(),
 	},

--- a/src/reporters/plain.ts
+++ b/src/reporters/plain.ts
@@ -32,7 +32,7 @@ export function* plainReporter(filesRuleReports: FilesRuleReports) {
 						"gray",
 						`  ${report.range.begin.line}:${report.range.begin.column}`,
 					),
-					report.message,
+					report.message.primary,
 					styleText("yellow", report.ruleId),
 				]),
 		);

--- a/src/rules/consecutiveNonNullAssertions.ts
+++ b/src/rules/consecutiveNonNullAssertions.ts
@@ -8,8 +8,14 @@ export default createRule({
 		preset: "logical",
 	},
 	messages: {
-		consecutiveNonNullAssertion:
-			"Consecutive non-null assertion operators are unnecessary.",
+		consecutiveNonNullAssertion: {
+			primary: "Consecutive non-null assertion operators are unnecessary.",
+			secondary: [
+				"The non-null assertion operator (`!`) is used to assert that a value is not null or undefined.",
+				"Using it multiple times in a row does not do anything, and just takes up space unnecessarily.",
+			],
+			suggestions: ["Remove the redundant non-null assertion operator."],
+		},
 	},
 	setup(context) {
 		return {

--- a/src/rules/forInArrays.ts
+++ b/src/rules/forInArrays.ts
@@ -11,8 +11,18 @@ export default createRule({
 		preset: "logical",
 	},
 	messages: {
-		preferModules:
-			"For-in loops over arrays have surprising behavior that often leads to bugs.",
+		forIn: {
+			primary:
+				"For-in loops over arrays have surprising behavior that often leads to bugs.",
+			secondary: [
+				"A for-in loop (`for (const i in o)`) iterates over all enumerable properties of an object, including those that are not array indices.",
+				"This can lead to unexpected behavior when used with arrays, as it may include properties that are not part of the array's numeric indices.",
+				"It also returns the index key (`i`) as a string, which is not the expected numeric type for array indices.",
+			],
+			suggestions: [
+				"Use a construct more suited for arrays, such as a for-of loop (`for (const i of o)`).",
+			],
+		},
 	},
 	setup(context) {
 		function hasNumberLikeLength(type: ts.Type): boolean {
@@ -44,7 +54,7 @@ export default createRule({
 
 				if (isArrayLike(type)) {
 					context.report({
-						message: "preferModules",
+						message: "forIn",
 						range: {
 							begin: node.getStart(),
 							end: node.statement.getStart() - 1,

--- a/src/rules/namespaceDeclarations.ts
+++ b/src/rules/namespaceDeclarations.ts
@@ -10,8 +10,16 @@ export default createRule({
 		preset: "logical",
 	},
 	messages: {
-		preferModules:
-			"Prefer using ECMAScript modules over legacy TypeScript namespaces.",
+		preferModules: {
+			primary:
+				"Prefer using ECMAScript modules over legacy TypeScript namespaces.",
+			secondary: [
+				"Namespaces are a legacy feature of TypeScript that can lead to confusion and are not compatible with ECMAScript modules.",
+			],
+			suggestions: [
+				"Modern codebases generally use `export` and `import` statements to define and use ECMAScript modules instead.",
+			],
+		},
 	},
 	options: {
 		allowDeclarations: z.boolean().default(false),

--- a/src/testing/createReportSnapshot.ts
+++ b/src/testing/createReportSnapshot.ts
@@ -34,7 +34,7 @@ function createReportSnapshotAt(
 	const injectionPrefix = " ".repeat(column);
 	const injectedLines = [
 		injectionPrefix + "~".repeat(width),
-		injectionPrefix + report.message,
+		injectionPrefix + report.message.primary,
 	];
 
 	return [

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -2,12 +2,12 @@ import type * as ts from "typescript";
 
 import { RuleReport } from "./reports.js";
 
-export interface RuleContext<Message extends string> {
-	report: RuleReporter<Message>;
+export interface RuleContext<MessageId extends string> {
+	report: RuleReporter<MessageId>;
 	sourceFile: ts.SourceFile;
 	typeChecker: ts.TypeChecker;
 }
 
-export type RuleReporter<Message extends string> = (
-	report: RuleReport<Message>,
+export type RuleReporter<MessageId extends string> = (
+	report: RuleReport<MessageId>,
 ) => void;

--- a/src/types/reports.ts
+++ b/src/types/reports.ts
@@ -1,8 +1,5 @@
 import type * as ts from "typescript";
 
-/**
- * Mapping from file paths to their rule reports.
- */
 export type CharacterReportRange = CharacterReportRangeObject | ts.Node;
 
 export interface CharacterReportRangeObject {
@@ -31,12 +28,38 @@ export interface NormalizedReportRangeObject {
 	end: ColumnAndLine;
 }
 
-export interface NormalizedRuleReport<Message extends string = string> {
-	message: Message;
+/**
+ * A full rule report that can be used to display to users via a reporter.
+ */
+export interface NormalizedRuleReport {
+	message: ReportMessageData;
 	range: NormalizedReportRangeObject;
 }
 
+/**
+ * The internal raw rule report format used by rules themselves.
+ */
 export interface RuleReport<Message extends string = string> {
 	message: Message;
 	range: CharacterReportRange;
+}
+
+/**
+ * Full data for a report message to be displayed to users.
+ */
+export interface ReportMessageData {
+	/**
+	 * A single sentence explaining what's wrong.
+	 */
+	primary: string;
+
+	/**
+	 * Additional sentences explaining the problem in more detail.
+	 */
+	secondary: string[];
+
+	/**
+	 * Recommendations for how to fix the problem.
+	 */
+	suggestions: string[];
 }

--- a/src/types/rules.ts
+++ b/src/types/rules.ts
@@ -1,5 +1,6 @@
 import { RuleContext } from "./context.js";
 import { TSNode, TSNodeName, TSNodesByName } from "./nodes.js";
+import { ReportMessageData } from "./reports.js";
 import { AnyOptionalSchema, InferredObject } from "./shapes.js";
 
 export type AnyRuleDefinition<
@@ -15,13 +16,13 @@ export interface RuleAbout {
 
 export interface RuleDefinition<
 	About extends RuleAbout,
-	Message extends string,
+	MessageId extends string,
 	OptionsSchema extends AnyOptionalSchema | undefined,
 > {
 	about: About;
-	messages: Record<Message, string>;
+	messages: Record<MessageId, ReportMessageData>;
 	options?: OptionsSchema;
-	setup: RuleSetup<Message, InferredObject<OptionsSchema>>;
+	setup: RuleSetup<MessageId, InferredObject<OptionsSchema>>;
 }
 
 export type RuleSetup<Message extends string, Options> = (


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #60
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Switches message data from `string`s to a full `ReportMessageData` object. `NormalizedRuleReport` now contains those data objects.

❤️‍🔥