### PR TITLE
feat: implemented initial --fix mode

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,6 +42,10 @@ export default tseslint.config(
 			},
 		},
 		rules: {
+			"@typescript-eslint/no-unnecessary-condition": [
+				"error",
+				{ allowConstantLoopConditions: true },
+			],
 			"@typescript-eslint/restrict-template-expressions": [
 				"error",
 				{ allowNumber: true },

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -3,7 +3,8 @@ import { parseArgs } from "node:util";
 
 import { isConfig } from "../configs/isConfig.js";
 import { plainReporter } from "../reporters/plain.js";
-import { runConfig } from "../running/lintConfig.js";
+import { runConfig } from "../running/runConfig.js";
+import { runConfigFixing } from "../running/runConfigFixing.js";
 import { findConfigFileName } from "./findConfigFileName.js";
 import { packageData } from "./packageData.js";
 
@@ -12,6 +13,9 @@ const log = debugForFile(import.meta.filename);
 export async function runCli() {
 	const { values } = parseArgs({
 		options: {
+			fix: {
+				type: "boolean",
+			},
 			help: {
 				type: "boolean",
 			},
@@ -54,11 +58,14 @@ export async function runCli() {
 	}
 
 	log("Running with Flint config: %s", configFileName);
-	const allRuleReports = await runConfig(config.definition);
 
-	for (const line of plainReporter(allRuleReports)) {
+	const filesResults = await (values.fix
+		? runConfigFixing(config.definition)
+		: runConfig(config.definition));
+
+	for (const line of plainReporter(filesResults)) {
 		console.log(line);
 	}
 
-	return allRuleReports.size ? 1 : 0;
+	return filesResults.filesResults.size ? 1 : 0;
 }

--- a/src/fixing/applyFileFixes.ts
+++ b/src/fixing/applyFileFixes.ts
@@ -1,0 +1,41 @@
+import { debugForFile } from "debug-for-file";
+import * as fs from "node:fs/promises";
+
+import { FileResultsWithFixes } from "../types/results.js";
+import { orderFixesLastToFirstWithoutOverlaps } from "./ordering.js";
+
+const log = debugForFile(import.meta.filename);
+
+export async function applyFileFixes(
+	absoluteFilePath: string,
+	results: FileResultsWithFixes,
+) {
+	log("Applying fixes to file: %s", absoluteFilePath);
+
+	const fixes = orderFixesLastToFirstWithoutOverlaps(
+		results.fixableReports.map((report) => report.fix),
+	);
+
+	const updatedFileContent = fixes.reduce(
+		(updatedFileContent, fix) =>
+			updatedFileContent.slice(0, fix.range.begin) +
+			fix.text +
+			updatedFileContent.slice(fix.range.end),
+		results.originalContent,
+	);
+
+	// TODO: Eventually, the file system should be abstracted
+	// Direct fs write calls don't make sense in e.g. virtual file systems
+	// https://github.com/JoshuaKGoldberg/flint/issues/69
+	// https://github.com/JoshuaKGoldberg/flint/issues/73
+	await fs.writeFile(absoluteFilePath, updatedFileContent);
+
+	log(
+		"Writing %d of %d fixes to file: %s",
+		fixes.length,
+		results.fixableReports.length,
+		absoluteFilePath,
+	);
+
+	return updatedFileContent;
+}

--- a/src/fixing/applyFixes.ts
+++ b/src/fixing/applyFixes.ts
@@ -1,0 +1,20 @@
+import { debugForFile } from "debug-for-file";
+
+import { FileResultsWithFixes } from "../types/results.js";
+import { applyFileFixes } from "./applyFileFixes.js";
+
+const log = debugForFile(import.meta.filename);
+
+export async function applyFixes(
+	filesResults: Map<string, FileResultsWithFixes>,
+) {
+	log("Applying fixes to %d file(s)", filesResults.size);
+
+	await Promise.all(
+		filesResults.entries().map(async ([absoluteFilePath, fileResults]) => {
+			await applyFileFixes(absoluteFilePath, fileResults);
+		}),
+	);
+
+	log("Finished applying fixes.");
+}

--- a/src/fixing/ordering.ts
+++ b/src/fixing/ordering.ts
@@ -1,0 +1,19 @@
+import { Fix } from "../types/fixes.js";
+
+export const orderFixesLastToFirstWithoutOverlaps = (fixes: Fix[]): Fix[] => {
+	const ordered = fixes.toSorted((a, b) => a.range.end - b.range.end);
+	const orderedWithoutOverlaps: Fix[] = [];
+	let lastStart = Infinity;
+
+	for (let i = ordered.length - 1; i >= 0; i -= 1) {
+		const fix = ordered[i];
+		if (fix.range.end > lastStart) {
+			continue;
+		}
+
+		lastStart = fix.range.begin;
+		orderedWithoutOverlaps.push(fix);
+	}
+
+	return orderedWithoutOverlaps;
+};

--- a/src/rules/consecutiveNonNullAssertions.ts
+++ b/src/rules/consecutiveNonNullAssertions.ts
@@ -20,15 +20,23 @@ export default typescript.createRule({
 	setup(context) {
 		return {
 			NonNullExpression(node) {
-				if (node.parent.kind === ts.SyntaxKind.NonNullExpression) {
-					context.report({
-						message: "consecutiveNonNullAssertion",
-						range: {
-							begin: node.end,
-							end: node.parent.end + 1,
-						},
-					});
+				if (node.parent.kind !== ts.SyntaxKind.NonNullExpression) {
+					return;
 				}
+
+				const range = {
+					begin: node.end,
+					end: node.parent.end + 1,
+				};
+
+				context.report({
+					fix: {
+						range,
+						text: "",
+					},
+					message: "consecutiveNonNullAssertion",
+					range,
+				});
 			},
 		};
 	},

--- a/src/running/runConfigFixing.ts
+++ b/src/running/runConfigFixing.ts
@@ -1,0 +1,65 @@
+import { debugForFile } from "debug-for-file";
+
+import { applyFixes } from "../fixing/applyFixes.js";
+import { ConfigDefinition } from "../types/configs.js";
+import {
+	FileResultsWithFixes,
+	RunConfigResultsWithFixes,
+} from "../types/results.js";
+import { hasFix } from "../utils/predicates.js";
+import { runConfig } from "./runConfig.js";
+
+const log = debugForFile(import.meta.filename);
+
+const maximumIterations = 10;
+
+export async function runConfigFixing(
+	config: ConfigDefinition,
+): Promise<RunConfigResultsWithFixes> {
+	let fixed = new Set<string>();
+	let iteration = 0;
+
+	while (true) {
+		iteration += 1;
+		log(
+			"Starting fix iteration %d of maximum %d",
+			iteration,
+			maximumIterations,
+		);
+
+		const { filesResults } = await runConfig(config);
+
+		// TODO: All these Map and Object creations are probably inefficient...
+		const fixableResults = new Map(
+			filesResults
+				.entries()
+				.map(
+					([absoluteFilePath, filesResults]): [
+						string,
+						FileResultsWithFixes,
+					] => [
+						absoluteFilePath,
+						{
+							...filesResults,
+							fixableReports: filesResults.allReports.filter(hasFix),
+						},
+					],
+				)
+				.filter(([, filesResults]) => filesResults.fixableReports.length > 0),
+		);
+
+		if (fixableResults.size === 0) {
+			log("No fixable reports found, stopping.");
+			return { filesResults, fixed };
+		}
+
+		fixed = fixed.union(new Set(fixableResults.keys()));
+
+		await applyFixes(fixableResults);
+
+		if (iteration >= maximumIterations) {
+			log("Passed maximum iterations of %d, halting.", maximumIterations);
+			return { filesResults, fixed };
+		}
+	}
+}

--- a/src/types/fixes.ts
+++ b/src/types/fixes.ts
@@ -1,0 +1,16 @@
+import { CharacterReportRange } from "./ranges.js";
+
+/**
+ * A "fix" (change to text) to be made to a file.
+ */
+export interface Fix {
+	/**
+	 * Range of text in the files to be updated.
+	 */
+	range: CharacterReportRange;
+
+	/**
+	 * New value for the text in the range.
+	 */
+	text: string;
+}

--- a/src/types/ranges.ts
+++ b/src/types/ranges.ts
@@ -1,0 +1,20 @@
+/**
+ * The column and line of a character in a source file, as visualized to users.
+ */
+export interface ColumnAndLine {
+	column: number;
+	line: number;
+
+	/**
+	 * The original raw character position in the source file.
+	 */
+	raw: number;
+}
+
+/**
+ * A range of characters in a source file, as reported by a rule.
+ */
+export interface CharacterReportRange {
+	begin: number;
+	end: number;
+}

--- a/src/types/reports.ts
+++ b/src/types/reports.ts
@@ -1,26 +1,12 @@
-/**
- * A range of characters in a source file, as reported by a rule.
- */
-export interface CharacterReportRange {
-	begin: number;
-	end: number;
-}
-
-/**
- * The column and line of a character in a source file, as visualized to users.
- */
-export interface ColumnAndLine {
-	column: number;
-	line: number;
-
-	/**
-	 * The original raw character position in the source file.
-	 */
-	raw: number;
-}
+import { Fix } from "./fixes.js";
+import { CharacterReportRange, ColumnAndLine } from "./ranges.js";
 
 export interface FileRuleReport extends NormalizedRuleReport {
 	ruleId: string;
+}
+
+export interface FileRuleReportWithFix extends FileRuleReport {
+	fix: Fix;
 }
 
 export type FilesRuleReports = Map<string, FileRuleReport[]>;
@@ -34,18 +20,25 @@ export interface NormalizedReportRangeObject {
  * A full rule report that can be used to display to users via a reporter.
  */
 export interface NormalizedRuleReport {
+	fix?: Fix;
 	message: ReportMessageData;
 	range: NormalizedReportRangeObject;
+}
+
+export interface NormalizedRuleReportWithFix extends NormalizedRuleReport {
+	fix: Fix;
 }
 
 /**
  * The internal raw rule report format used by rules themselves.
  */
 export interface RuleReport<Message extends string = string> {
+	fix?: Fix;
+
 	message: Message;
 
 	/**
-	 * Which specific
+	 * Which specific characters in the source file are affected by this report.
 	 */
 	range: CharacterReportRange;
 }

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -1,0 +1,22 @@
+import { FileRuleReport, FileRuleReportWithFix } from "./reports.js";
+
+export interface FileResults {
+	allReports: FileRuleReport[];
+	originalContent: string;
+}
+
+export interface FileResultsWithFixes extends FileResults {
+	fixableReports: FileRuleReportWithFix[];
+}
+
+export interface RunConfigResults {
+	filesResults: Map<string, FileResults>;
+}
+
+export interface RunConfigResultsMaybeWithFixes extends RunConfigResults {
+	fixed?: Set<string>;
+}
+
+export interface RunConfigResultsWithFixes extends RunConfigResults {
+	fixed: Set<string>;
+}

--- a/src/typescript/createTypeScriptFileFromProgram.ts
+++ b/src/typescript/createTypeScriptFileFromProgram.ts
@@ -15,6 +15,7 @@ export function createTypeScriptFileFromProgram(
 			const context = {
 				report: (report: RuleReport) => {
 					reports.push({
+						...report,
 						message: rule.messages[report.message],
 						range: normalizeRange(report.range, sourceFile),
 					});

--- a/src/typescript/getNodeRange.ts
+++ b/src/typescript/getNodeRange.ts
@@ -1,6 +1,6 @@
 import type * as ts from "typescript";
 
-import { CharacterReportRange } from "../types/reports.js";
+import { CharacterReportRange } from "../types/ranges.js";
 
 export function getNodeRange(node: ts.Node): CharacterReportRange {
 	return {

--- a/src/typescript/normalizeRange.ts
+++ b/src/typescript/normalizeRange.ts
@@ -1,9 +1,7 @@
 import type * as ts from "typescript";
 
-import {
-	CharacterReportRange,
-	NormalizedReportRangeObject,
-} from "../types/reports.js";
+import { NormalizedReportRangeObject } from "../types/reports.js";
+import { CharacterReportRange } from "../types/ranges.js";
 
 export function normalizeRange(
 	original: CharacterReportRange,

--- a/src/typescript/normalizeRange.ts
+++ b/src/typescript/normalizeRange.ts
@@ -1,7 +1,7 @@
 import type * as ts from "typescript";
 
-import { NormalizedReportRangeObject } from "../types/reports.js";
 import { CharacterReportRange } from "../types/ranges.js";
+import { NormalizedReportRangeObject } from "../types/reports.js";
 
 export function normalizeRange(
 	original: CharacterReportRange,

--- a/src/utils/predicates.ts
+++ b/src/utils/predicates.ts
@@ -1,0 +1,7 @@
+import { FileRuleReport, FileRuleReportWithFix } from "../types/reports.js";
+
+export function hasFix(
+	report: FileRuleReport,
+): report is FileRuleReportWithFix {
+	return !!("fix" in report);
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #69
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements a basic `--fix` mode. Rule reports now have an optional `fix` property for a basic representation of a character range & new text for that range. 

Fixes are applied last-to-first in a rule file, using a very greedy algorithm for avoiding overlaps. This mirrors how I set up [automutate's fix ordering](https://github.com/automutate/automutate/blob/5f114882c341bde148a67750a8dc5d66ec9c1d23/src/ordering.ts#L41) ~6.5 years ago. Nifty to see concepts resurfacing.

❤️‍🔥