### PR TITLE
fix: always log formatting result in plain reporter

### DIFF
--- a/src/reporters/plain.ts
+++ b/src/reporters/plain.ts
@@ -12,8 +12,6 @@ export function* plainReporter(
 ) {
 	const reportTotals = { all: 0, fixable: 0 };
 
-	yield "";
-
 	for (const [filePath, fileResult] of configResults.filesResults) {
 		reportTotals.all += fileResult.allReports.length;
 		reportTotals.fixable += fileResult.allReports.filter(hasFix).length;
@@ -53,7 +51,6 @@ export function* plainReporter(
 
 	if (configResults.filesResults.size === 0) {
 		yield styleText("green", "No linting issues found.");
-		return;
 	} else {
 		yield styleText(
 			"red",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #85
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes the excess `yield ""` (not really needed, just nice to have) and `return;`.

❤️‍🔥