### PR TITLE
fix: invalidate cache for file when external dependency is not cached

### DIFF
--- a/src/cache/readFromCache.ts
+++ b/src/cache/readFromCache.ts
@@ -64,7 +64,7 @@ export async function readFromCache(
 			for (const dependency of fileCached.dependencies) {
 				if (!allFilePaths.has(dependency)) {
 					log(
-						"Directly invalidating cache for: %s due to dependency %s not being in linted files",
+						"Directly invalidating cache for: %s due to dependency %s not being in linted files cache",
 						filePath,
 						dependency,
 					);
@@ -74,7 +74,7 @@ export async function readFromCache(
 			}
 		}
 
-		const timestampCached = fileCached?.timestamp;
+		const timestampCached = fileCached.timestamp;
 		const timestampTouched = getFileTouchTime(filePath);
 		if (timestampTouched > timestampCached) {
 			log(

--- a/src/cache/readFromCache.ts
+++ b/src/cache/readFromCache.ts
@@ -23,6 +23,7 @@ export async function readFromCache(
 		return undefined;
 	}
 
+	// The config file and package.json are hardcoded to always be dependencies of all files
 	for (const filePath of [configFilePath, "package.json"]) {
 		if (!Object.hasOwn(cache.configs, filePath)) {
 			log(
@@ -52,13 +53,28 @@ export async function readFromCache(
 
 	// Any files touched since last cache write will need to be re-linted
 	for (const filePath of allFilePaths) {
-		const timestampCached = cached.get(filePath)?.timestamp;
-		if (timestampCached === undefined) {
+		const fileCached = cached.get(filePath);
+		if (!fileCached) {
 			log("No cache available for: %s", filePath);
 			markAsUncached(filePath);
 			continue;
 		}
 
+		if (fileCached.dependencies) {
+			for (const dependency of fileCached.dependencies) {
+				if (!allFilePaths.has(dependency)) {
+					log(
+						"Directly invalidating cache for: %s due to dependency %s not being in linted files",
+						filePath,
+						dependency,
+					);
+					markAsUncached(filePath);
+					continue;
+				}
+			}
+		}
+
+		const timestampCached = fileCached?.timestamp;
 		const timestampTouched = getFileTouchTime(filePath);
 		if (timestampTouched > timestampCached) {
 			log(


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #119
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a check for each file dependency: if it's not in the cache, the file is invalidated.

❤️‍🔥