### PR TITLE
feat: wrap detailed presenter to column width

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 		"unist-util-visit": "^5.0.0",
 		"vfile": "^6.0.3",
 		"vfile-location": "^5.0.3",
+		"wrap-ansi": "^9.0.0",
 		"yaml-unist-parser": "^2.0.5",
 		"zod": "^3.25.67"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,12 @@ importers:
       remark-parse:
         specifier: ^11.0.0
         version: 11.0.0
+      slice-ansi:
+        specifier: ^7.1.0
+        version: 7.1.0
+      string-width:
+        specifier: ^7.2.0
+        version: 7.2.0
       text-table-fast:
         specifier: ^0.1.0
         version: 0.1.0
@@ -56,6 +62,9 @@ importers:
       vfile-location:
         specifier: ^5.0.3
         version: 5.0.3
+      wrap-ansi:
+        specifier: ^9.0.0
+        version: 9.0.0
       yaml-unist-parser:
         specifier: ^2.0.5
         version: 2.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,12 +38,6 @@ importers:
       remark-parse:
         specifier: ^11.0.0
         version: 11.0.0
-      slice-ansi:
-        specifier: ^7.1.0
-        version: 7.1.0
-      string-width:
-        specifier: ^7.2.0
-        version: 7.2.0
       text-table-fast:
         specifier: ^0.1.0
         version: 0.1.0

--- a/src/presenters/detailed/detailedPresenter.ts
+++ b/src/presenters/detailed/detailedPresenter.ts
@@ -6,6 +6,7 @@ import { presentHeader } from "../shared/header.js";
 import { presentSummary } from "../shared/summary.js";
 import { indenter } from "./constants.js";
 import { createDetailedReport } from "./createDetailedReport.js";
+import { wrapIfNeeded } from "./wrapIfNeeded.js";
 
 export const detailedPresenter: Presenter = {
 	about: {
@@ -22,15 +23,17 @@ export const detailedPresenter: Presenter = {
 					counts.files += 1;
 					counts.fixable += reports.filter(hasFix).length;
 
+					const width = process.stdout.columns - indenter.length;
+
 					yield chalk.gray("\n╭");
 					yield chalk.hex("ff7777")("./");
-					yield chalk.bold.hex("ff4949")(file.filePath);
+					yield* wrapIfNeeded(chalk.bold.hex("ff4949"), file.filePath, width);
 
 					let widest = 16;
 
 					for (const report of reports) {
 						yield `\n${indenter}\n`;
-						yield* createDetailedReport(report, file.text);
+						yield* createDetailedReport(report, file.text, width);
 
 						widest = Math.max(
 							widest,
@@ -43,9 +46,7 @@ export const detailedPresenter: Presenter = {
 					}
 
 					yield `\n${indenter}\n`;
-					yield chalk.gray(
-						`╰${"─".repeat(Math.min(widest, process.stdout.columns - 2))}`,
-					);
+					yield chalk.gray(`╰${"─".repeat(Math.min(widest, width))}`);
 					yield "\n";
 				},
 				*summarize(summaryContext) {

--- a/src/presenters/detailed/formatSuggestion.ts
+++ b/src/presenters/detailed/formatSuggestion.ts
@@ -10,6 +10,5 @@ export function formatSuggestion(suggestion: string) {
 				)
 				.join("`"),
 		),
-		"\n",
 	].join("");
 }

--- a/src/presenters/detailed/wrapIfNeeded.ts
+++ b/src/presenters/detailed/wrapIfNeeded.ts
@@ -1,0 +1,19 @@
+import { ChalkInstance } from "chalk";
+import wrapAnsi from "wrap-ansi";
+
+import { indenter } from "./constants.js";
+
+export function wrapIfNeeded(
+	lineFormat: ChalkInstance,
+	text: string,
+	width: number,
+) {
+	const lines = wrapAnsi(text, width).split("\n");
+
+	return [
+		lineFormat(lines[0]),
+		...lines.slice(1).map((line) => lineFormat(line)),
+	]
+		.join("\n")
+		.replaceAll(`\n`, `\n${indenter} `);
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #135
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Calculates an approximate maximum width to print lines within based on `process.stdout.columns`. The math is a little inaccurate but I don't think most users would really notice that.

<img width="675" alt="Screenshot of 3 lint reports across 2 files in from running with --presenter detailed. Each file wraps its reports on the left and bottom with a thin gray line. Reports have syntax highlighting above squigglies, along with a blue suggestion, yellow detail text, and green link to docs. The terminal screen is narrow enough that each description and suggestion has to wrap onto the next line, and they're staying within their wrapping thin gray lines" src="https://github.com/user-attachments/assets/039dc86c-c33f-432a-b9ac-f465f3dc2bba" />

❤️‍🔥