### PR TITLE
feat: additionally report language diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,6 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         if: always()
         uses: codecov/codecov-action@v3
-  type_check:
-    name: Type Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: ./.github/actions/prepare
-      - run: pnpm tsc
 
 name: CI
 

--- a/src/cli/runCliOnce.ts
+++ b/src/cli/runCliOnce.ts
@@ -55,6 +55,10 @@ export async function runCliOnce(
 		return 1;
 	}
 
+	if (configResults.languageDiagnostics.length) {
+		return 1;
+	}
+
 	for (const fileResults of configResults.filesResults.values()) {
 		if (fileResults.reports.length) {
 			return 1;

--- a/src/fixtures/one-failure.ts
+++ b/src/fixtures/one-failure.ts
@@ -1,3 +1,5 @@
 for (const i in ["a", "b", "c"]) {
 	// ...
 }
+
+let a: string = 123;

--- a/src/presenters/briefPresenterFactory.ts
+++ b/src/presenters/briefPresenterFactory.ts
@@ -6,6 +6,7 @@ import { PresenterFactory } from "../types/presenters.js";
 import { makeAbsolute } from "../utils/makeAbsolute.js";
 import { hasFix } from "../utils/predicates.js";
 import { presentHeader } from "./shared/header.js";
+import { presentDiagnostics } from "./shared/presentDiagnostics.js";
 import { presentSummary } from "./shared/summary.js";
 
 export const briefPresenterFactory: PresenterFactory = {
@@ -48,6 +49,9 @@ export const briefPresenterFactory: PresenterFactory = {
 			},
 			*summarize(summaryContext) {
 				yield* presentSummary(counts, summaryContext);
+				yield* presentDiagnostics(
+					summaryContext.configResults.languageDiagnostics,
+				);
 			},
 		};
 	},

--- a/src/presenters/detailed/detailedPresenterFactory.ts
+++ b/src/presenters/detailed/detailedPresenterFactory.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { PresenterFactory } from "../../types/presenters.js";
 import { hasFix } from "../../utils/predicates.js";
 import { presentHeader } from "../shared/header.js";
+import { presentDiagnostics } from "../shared/presentDiagnostics.js";
 import { presentSummary } from "../shared/summary.js";
 import { indenter } from "./constants.js";
 import { createDetailedReport } from "./createDetailedReport.js";
@@ -50,6 +51,9 @@ export const detailedPresenterFactory: PresenterFactory = {
 			},
 			*summarize(summaryContext) {
 				yield* presentSummary(counts, summaryContext);
+				yield* presentDiagnostics(
+					summaryContext.configResults.languageDiagnostics,
+				);
 			},
 		};
 	},

--- a/src/presenters/shared/presentDiagnostics.ts
+++ b/src/presenters/shared/presentDiagnostics.ts
@@ -1,0 +1,23 @@
+import { styleText } from "node:util";
+
+import { LanguageFileDiagnostic } from "../../types/languages.js";
+import { pluralize } from "../pluralize.js";
+
+export function* presentDiagnostics(diagnostics: LanguageFileDiagnostic[]) {
+	if (!diagnostics.length) {
+		return;
+	}
+
+	yield "\n";
+	yield styleText(
+		"yellow",
+		`⚠️  Additionally found ${pluralize(diagnostics.length, "diagnostic")} from tsc:`,
+	);
+	yield "\n\n";
+
+	for (const diagnostic of diagnostics) {
+		yield diagnostic.text;
+	}
+
+	yield "\n\n";
+}

--- a/src/running/lintFile.ts
+++ b/src/running/lintFile.ts
@@ -9,8 +9,8 @@ import { computeRulesWithOptions } from "./computeRulesWithOptions.js";
 const log = debugForFile(import.meta.filename);
 
 export function lintFile(
-	fileFactories: CachedFactory<AnyLanguage, LanguageFileFactory>,
 	filePathAbsolute: string,
+	languageFactories: CachedFactory<AnyLanguage, LanguageFileFactory>,
 	ruleDefinitions: ConfigRuleDefinition[],
 ) {
 	log("Linting: %s:", filePathAbsolute);
@@ -19,7 +19,7 @@ export function lintFile(
 	const reports: FileRuleReport[] = [];
 
 	const languageFiles = new CachedFactory((language: AnyLanguage) =>
-		fileFactories.get(language).prepareFileOnDisk(filePathAbsolute),
+		languageFactories.get(language).prepareFileOnDisk(filePathAbsolute),
 	);
 	const rulesWithOptions = computeRulesWithOptions(ruleDefinitions);
 

--- a/src/running/runConfigFixing.ts
+++ b/src/running/runConfigFixing.ts
@@ -31,7 +31,8 @@ export async function runConfigFixing(
 		// Why read file many time when few do trick?
 		// Or, at least it should all be virtual...
 		// https://github.com/JoshuaKGoldberg/flint/issues/73
-		const { allFilePaths, filesResults } = await runConfig(configDefinition);
+		const { allFilePaths, filesResults, languageDiagnostics } =
+			await runConfig(configDefinition);
 
 		// TODO: All these Map and Object creations are probably inefficient...
 		const fixableResults = new Map(
@@ -54,7 +55,7 @@ export async function runConfigFixing(
 
 		if (fixableResults.size === 0) {
 			log("No fixable reports found, stopping.");
-			return { allFilePaths, filesResults, fixed };
+			return { allFilePaths, filesResults, fixed, languageDiagnostics };
 		}
 
 		fixed = fixed.union(new Set(fixableResults.keys()));
@@ -63,7 +64,7 @@ export async function runConfigFixing(
 
 		if (iteration >= maximumIterations) {
 			log("Passed maximum iterations of %d, halting.", maximumIterations);
-			return { allFilePaths, filesResults, fixed };
+			return { allFilePaths, filesResults, fixed, languageDiagnostics };
 		}
 	}
 }

--- a/src/types/languages.ts
+++ b/src/types/languages.ts
@@ -36,9 +36,6 @@ export interface CreateRule<AstNodesByName, ContextServices extends object> {
 	): Rule<About, AstNodesByName, ContextServices, MessageId, OptionsSchema>;
 }
 
-/**
- * A single lint rule, as used by users in configs and to create rules.
- */
 export interface Language<AstNodesByName, ContextServices extends object>
 	extends LanguageDefinition {
 	createRule: CreateRule<AstNodesByName, ContextServices>;
@@ -47,6 +44,13 @@ export interface Language<AstNodesByName, ContextServices extends object>
 
 export interface LanguageAbout {
 	name: string;
+}
+
+export type LanguageDiagnostics = LanguageFileDiagnostic[];
+
+export interface LanguageFileDiagnostic {
+	code: string;
+	text: string;
 }
 
 /**
@@ -95,6 +99,7 @@ export interface LanguageFileDefinition extends Partial<Disposable> {
  * Creates wrappers around files to be linted.
  */
 export interface LanguageFileFactory extends Disposable {
+	getDiagnostics?(): LanguageDiagnostics;
 	prepareFileOnDisk(filePathAbsolute: string): LanguageFile;
 	prepareFileVirtually(
 		filePathAbsolute: string,
@@ -106,6 +111,7 @@ export interface LanguageFileFactory extends Disposable {
  * Internal definition of how to create wrappers around files to be linted.
  */
 export interface LanguageFileFactoryDefinition extends Partial<Disposable> {
+	getDiagnostics?(): LanguageDiagnostics;
 	prepareFileOnDisk(filePathAbsolute: string): LanguageFileDefinition;
 	prepareFileVirtually(
 		filePathAbsolute: string,

--- a/src/types/linting.ts
+++ b/src/types/linting.ts
@@ -1,4 +1,5 @@
 import { FileCacheStorage } from "./cache.js";
+import { LanguageFileDiagnostic } from "./languages.js";
 import { FileRuleReport, FileRuleReportWithFix } from "./reports.js";
 
 export interface FileResults {
@@ -14,6 +15,7 @@ export interface RunConfigResults {
 	allFilePaths: Set<string>;
 	cached?: Map<string, FileCacheStorage>;
 	filesResults: Map<string, FileResults>;
+	languageDiagnostics: LanguageFileDiagnostic[];
 }
 
 export interface RunConfigResultsMaybeWithFixes extends RunConfigResults {

--- a/src/typescript/createTypeScriptFileFromProjectService.ts
+++ b/src/typescript/createTypeScriptFileFromProjectService.ts
@@ -8,32 +8,9 @@ const log = debugForFile(import.meta.filename);
 
 export function createTypeScriptFileFromProjectService(
 	filePathAbsolute: string,
+	program: ts.Program,
 	service: ts.server.ProjectService,
 ): LanguageFileDefinition {
-	log("Opening client file:", filePathAbsolute);
-	service.openClientFile(filePathAbsolute);
-
-	log("Retrieving client services:", filePathAbsolute);
-	const scriptInfo = service.getScriptInfo(filePathAbsolute);
-	if (!scriptInfo) {
-		throw new Error(`Could not find script info for file: ${filePathAbsolute}`);
-	}
-
-	const defaultProject = service.getDefaultProjectForFile(
-		scriptInfo.fileName,
-		true,
-	);
-	if (!defaultProject) {
-		throw new Error(
-			`Could not find default project for file: ${filePathAbsolute}`,
-		);
-	}
-
-	const program = defaultProject.getLanguageService(true).getProgram();
-	if (!program) {
-		throw new Error(`Could not retrieve program for file: ${filePathAbsolute}`);
-	}
-
 	const sourceFile = program.getSourceFile(filePathAbsolute);
 	if (!sourceFile) {
 		throw new Error(`Could not retrieve source file for: ${filePathAbsolute}`);

--- a/src/typescript/formatDiagnostic.ts
+++ b/src/typescript/formatDiagnostic.ts
@@ -1,0 +1,203 @@
+// Adapted from: https://github.com/ArnaudBarre/tsl/blob/742a6f1a956705239f2149f856b1f572ade79919/src/formatDiagnostic.ts
+// ...which notes:
+// Adapted from: https://github.com/microsoft/TypeScript/blob/78c16795cdee70b9d9f0f248b6dbb6ba50994a59/src/compiler/program.ts#L680-L811
+
+// eslint-disable-next-line @eslint-community/eslint-comments/disable-enable-pair
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+import ts, {
+	flattenDiagnosticMessageText,
+	getLineAndCharacterOfPosition,
+	getPositionOfLineAndCharacter,
+	type SourceFile,
+} from "typescript";
+
+export interface RawDiagnostic {
+	file?: ts.SourceFile;
+	length: number;
+	message: string;
+	name: string;
+	relatedInformation?: ts.DiagnosticRelatedInformation[];
+	start: number;
+}
+
+export function formatDiagnostic(diagnostic: RawDiagnostic) {
+	let output = "";
+
+	if (diagnostic.file !== undefined) {
+		output += formatLocation(diagnostic.file, diagnostic.start);
+		output += " - ";
+	}
+	output += color(diagnostic.name, COLOR.Grey);
+	output += ": ";
+	output += diagnostic.message;
+	if (diagnostic.file !== undefined) {
+		output += "\n";
+		output += formatCodeSpan(
+			diagnostic.file,
+			diagnostic.start,
+			diagnostic.length,
+			"",
+			COLOR.Red,
+		);
+	}
+	if (diagnostic.relatedInformation) {
+		output += "\n";
+		for (const {
+			file,
+			length,
+			messageText,
+			start,
+		} of diagnostic.relatedInformation) {
+			const indent = "  ";
+			if (file) {
+				output += "\n";
+				output += " " + formatLocation(file, start!);
+				output += formatCodeSpan(file, start!, length!, indent, COLOR.Cyan);
+			}
+			output += "\n";
+			output += indent + flattenDiagnosticMessageText(messageText, "\n");
+		}
+	}
+
+	return output;
+}
+
+export function formatDiagnosticsSummary(diagnostics: RawDiagnostic[]) {
+	let output = "";
+	const filesMap = new Map<
+		ts.SourceFile,
+		{ count: number; firstLine: number }
+	>();
+	for (const d of diagnostics) {
+		if (d.file !== undefined) {
+			const file = filesMap.get(d.file);
+			if (file === undefined) {
+				const { line: firstLine } = d.file.getLineAndCharacterOfPosition(
+					d.start,
+				);
+				filesMap.set(d.file, { count: 1, firstLine });
+			} else {
+				file.count++;
+			}
+		}
+	}
+
+	if (filesMap.size > 0) {
+		const pluralize = (count: number, name: string) =>
+			count === 1 ? `${count} ${name}` : `${count} ${name}s`;
+		output += `\nFound ${pluralize(diagnostics.length, "error")} in ${pluralize(
+			filesMap.size,
+			"file",
+		)}`;
+	}
+	if (filesMap.size > 1) {
+		output += "\n\nErrors  Files";
+		for (const [file, { count, firstLine }] of filesMap) {
+			output += `\n${count.toString().padStart(6)}  ${displayFilename(file.fileName)}:${color(firstLine.toString(), COLOR.Grey)}`;
+		}
+	}
+	return output;
+}
+
+function color(text: string, formatStyle: string) {
+	return formatStyle + text + resetEscapeSequence;
+}
+
+const gutterStyleSequence = "\u001b[7m";
+const ellipsis = "...";
+const gutterSeparator = " ";
+const resetEscapeSequence = "\u001b[0m";
+const COLOR = {
+	Blue: "\u001b[94m",
+	Cyan: "\u001b[96m",
+	Grey: "\u001b[90m",
+	Red: "\u001b[91m",
+	Yellow: "\u001b[93m",
+};
+
+export function displayFilename(name: string) {
+	if (name.startsWith("./")) {
+		return name.slice(2);
+	}
+	return name.slice(process.cwd().length + 1);
+}
+
+export function formatLocation(file: SourceFile, start: number): string {
+	const { character, line } = getLineAndCharacterOfPosition(file, start);
+	const relativeFileName = displayFilename(file.fileName);
+	let output = "";
+	output += color(relativeFileName, COLOR.Cyan);
+	output += ":";
+	output += color(`${line + 1}`, COLOR.Yellow);
+	output += ":";
+	output += color(`${character + 1}`, COLOR.Yellow);
+	return output;
+}
+
+function formatCodeSpan(
+	file: SourceFile,
+	start: number,
+	length: number,
+	indent: string,
+	squiggleColor: string,
+) {
+	const { character: firstLineChar, line: firstLine } =
+		getLineAndCharacterOfPosition(file, start);
+	const { character: lastLineChar, line: lastLine } =
+		getLineAndCharacterOfPosition(file, start + length);
+	const lastLineInFile = getLineAndCharacterOfPosition(
+		file,
+		file.text.length,
+	).line;
+	const hasMoreThanFiveLines = lastLine - firstLine >= 4;
+	// eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+	let gutterWidth = (lastLine + 1 + "").length;
+	if (hasMoreThanFiveLines) {
+		gutterWidth = Math.max(ellipsis.length, gutterWidth);
+	}
+	let context = "";
+	for (let i = firstLine; i <= lastLine; i++) {
+		context += "\n";
+		if (hasMoreThanFiveLines && firstLine + 1 < i && i < lastLine - 1) {
+			context +=
+				indent +
+				color(ellipsis.padStart(gutterWidth), gutterStyleSequence) +
+				gutterSeparator +
+				"\n";
+			i = lastLine - 1;
+		}
+		const lineStart = getPositionOfLineAndCharacter(file, i, 0);
+		const lineEnd =
+			i < lastLineInFile
+				? getPositionOfLineAndCharacter(file, i + 1, 0)
+				: file.text.length;
+		let lineContent = file.text.slice(lineStart, lineEnd);
+		lineContent = lineContent.trimEnd();
+		lineContent = lineContent.replace(/\t/g, " ");
+		context +=
+			indent +
+			// eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+			color((i + 1 + "").padStart(gutterWidth), gutterStyleSequence) +
+			gutterSeparator;
+		context += lineContent + "\n";
+		context +=
+			indent +
+			color("".padStart(gutterWidth), gutterStyleSequence) +
+			gutterSeparator;
+		context += squiggleColor;
+		if (i === firstLine) {
+			const lastCharForLine = i === lastLine ? lastLineChar : void 0;
+			context += lineContent.slice(0, firstLineChar).replace(/\S/g, " ");
+			context += lineContent
+				.slice(firstLineChar, lastCharForLine)
+				.replace(/./g, "~");
+		} else if (i === lastLine) {
+			context += lineContent.slice(0, lastLineChar).replace(/./g, "~");
+		} else {
+			context += lineContent.replace(/./g, "~");
+		}
+		context += resetEscapeSequence;
+	}
+	return context;
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #139
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds an optional `getDiagnostics` to language definitions. The TypeScript language uses this to call `ts.getPreEmitDiagnostis` on every program that was generated for files.

This is set to always be enabled by default. A nice benefit of treating Flint as an experimental project: it doesn't need to have perfect configurability out-of-the-box.

❤️‍🔥