### PR TITLE
feat(core): allow rules to be async

### DIFF
--- a/packages/core/src/running/lintFile.ts
+++ b/packages/core/src/running/lintFile.ts
@@ -12,7 +12,7 @@ import { computeRulesWithOptions } from "./computeRulesWithOptions.js";
 
 const log = debugForFile(import.meta.filename);
 
-export function lintFile(
+export async function lintFile(
 	filePathAbsolute: string,
 	languageFactories: CachedFactory<AnyLanguage, LanguageFileFactory>,
 	ruleDefinitions: ConfigRuleDefinition[],
@@ -44,8 +44,9 @@ export function lintFile(
 			}
 		}
 
+		// TODO: These should probably be put in some kind of queue?
 		log("Running rule %s with options: %o", rule.about.id, options);
-		const ruleReports = file.runRule(rule, options as object | undefined);
+		const ruleReports = await file.runRule(rule, options as object | undefined);
 		log("Found %d reports from rule %s", ruleReports.length, rule.about.id);
 
 		reports.push(

--- a/packages/core/src/running/runConfig.ts
+++ b/packages/core/src/running/runConfig.ts
@@ -62,16 +62,18 @@ export async function runConfig(
 	// TODO: This is very slow and the whole thing should be refactored 🙌.
 	// The separate lintFile function recomputes rule options repeatedly.
 	// It'd be better to group files together in some way.
+	// It'd be better to group found files together in some way.
+	// Plus, this does an await in a for loop - should it use a queue?
 	for (const filePath of allFilePaths) {
 		const { dependencies, diagnostics, reports } =
 			cached?.get(filePath) ??
-			lintFile(
+			(await lintFile(
 				makeAbsolute(filePath),
 				languageFactories,
 				useDefinitions
 					.filter((use) => use.files.has(filePath))
 					.flatMap((use) => use.rules),
-			);
+			));
 
 		filesResults.set(filePath, {
 			dependencies: new Set(dependencies),

--- a/packages/core/src/types/languages.ts
+++ b/packages/core/src/types/languages.ts
@@ -1,3 +1,4 @@
+import { PromiseOrSync } from "./promises.js";
 import { NormalizedRuleReport } from "./reports.js";
 import {
 	AnyRule,
@@ -78,7 +79,7 @@ export interface LanguageFile extends Disposable {
 	>(
 		rule: AnyRule<RuleAbout, OptionsSchema>,
 		options: InferredObject<OptionsSchema>,
-	): NormalizedRuleReport[];
+	): PromiseOrSync<NormalizedRuleReport[]>;
 }
 
 /**
@@ -94,7 +95,7 @@ export interface LanguageFileDefinition extends Partial<Disposable> {
 	>(
 		rule: AnyRuleDefinition<OptionsSchema>,
 		options: InferredObject<OptionsSchema>,
-	): NormalizedRuleReport[];
+	): PromiseOrSync<NormalizedRuleReport[]>;
 }
 
 /**

--- a/packages/core/src/types/promises.ts
+++ b/packages/core/src/types/promises.ts
@@ -1,0 +1,1 @@
+export type PromiseOrSync<T> = Promise<T> | T;

--- a/packages/core/src/types/rules.ts
+++ b/packages/core/src/types/rules.ts
@@ -1,5 +1,6 @@
 import { RuleContext } from "./context.js";
 import { Language } from "./languages.js";
+import { PromiseOrSync } from "./promises.js";
 import { ReportMessageData } from "./reports.js";
 import { AnyOptionalSchema, InferredObject } from "./shapes.js";
 
@@ -89,7 +90,7 @@ export type RuleSetup<
 > = (
 	context: ContextServices & RuleContext<MessageId>,
 	options: Options,
-) => RuleVisitors<AstNodesByName> | undefined;
+) => PromiseOrSync<RuleVisitors<AstNodesByName> | undefined>;
 
 export type RuleVisitor<ASTNode> = (node: ASTNode) => void;
 

--- a/packages/json/src/createJsonFile.ts
+++ b/packages/json/src/createJsonFile.ts
@@ -17,7 +17,7 @@ export function createTypeScriptJsonFile(
 	const sourceFile = ts.parseJsonText(filePathAbsolute, sourceText);
 
 	return {
-		runRule(rule, options) {
+		async runRule(rule, options) {
 			const reports: NormalizedRuleReport[] = [];
 
 			const context = {
@@ -31,7 +31,7 @@ export function createTypeScriptJsonFile(
 				sourceFile,
 			};
 
-			const visitors = rule.setup(context, options);
+			const visitors = await rule.setup(context, options);
 
 			if (!visitors) {
 				return reports;

--- a/packages/md/src/createMarkdownFile.ts
+++ b/packages/md/src/createMarkdownFile.ts
@@ -24,7 +24,7 @@ export function createMarkdownFile(
 	const root = unified().use(remarkParse).parse(virtualFile);
 
 	return {
-		runRule(rule, options) {
+		async runRule(rule, options) {
 			const reports: NormalizedRuleReport[] = [];
 
 			const context = {
@@ -55,7 +55,7 @@ export function createMarkdownFile(
 				root,
 			};
 
-			const visitors = rule.setup(context, options);
+			const visitors = await rule.setup(context, options);
 
 			if (!visitors) {
 				return reports;

--- a/packages/ts/src/createTypeScriptFileFromProgram.ts
+++ b/packages/ts/src/createTypeScriptFileFromProgram.ts
@@ -42,7 +42,7 @@ export function createTypeScriptFileFromProgram(
 					}),
 				}));
 		},
-		runRule(rule, options) {
+		async runRule(rule, options) {
 			const reports: NormalizedRuleReport[] = [];
 
 			const context = {
@@ -57,7 +57,7 @@ export function createTypeScriptFileFromProgram(
 				typeChecker: program.getTypeChecker(),
 			};
 
-			const visitors = rule.setup(context, options);
+			const visitors = await rule.setup(context, options);
 
 			if (!visitors) {
 				return reports;

--- a/packages/yml/src/createYamlFile.ts
+++ b/packages/yml/src/createYamlFile.ts
@@ -23,7 +23,7 @@ export function createYamlFile(
 	const root = yamlParser.parse(sourceText);
 
 	return {
-		runRule(rule, options) {
+		async runRule(rule, options) {
 			const reports: NormalizedRuleReport[] = [];
 
 			const context = {
@@ -54,7 +54,7 @@ export function createYamlFile(
 				root,
 			};
 
-			const visitors = rule.setup(context, options);
+			const visitors = await rule.setup(context, options);
 
 			if (!visitors) {
 				return reports;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #172
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds and uses a new `PromiseOrSync` type for the return of rules' `setup`.

❤️‍🔥