### PR TITLE
feat(core): combine config exclude and globs into files

### DIFF
--- a/.changeset/fruity-pumas-jam.md
+++ b/.changeset/fruity-pumas-jam.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/core": patch
+---
+
+combine config exclude and globs into files

--- a/flint.config.ts
+++ b/flint.config.ts
@@ -1,24 +1,31 @@
 import { flint } from "@flint.fyi/plugin-flint";
 import { defineConfig, json, md, ts, yml } from "flint";
 
+// TODO: How to get the globs types piped through?
+// eslint-disable-next-line @eslint-community/eslint-comments/disable-enable-pair
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 export default defineConfig({
 	use: [
 		{
-			glob: json.globs.all,
+			files: json.files!.all,
 			rules: [json.presets.logical],
 		},
 		{
-			glob: md.globs.all,
+			files: md.files!.all,
 			rules: [md.presets.logical],
 		},
 		{
-			exclude: process.env.LINT_FIXTURES ? [] : ["packages/fixtures"],
-			glob: ts.globs.all,
+			files: {
+				exclude: process.env.LINT_FIXTURES ? [] : ["packages/fixtures"],
+				include: ts.files!.all,
+			},
 			rules: [flint.presets.logical, ts.presets.logical],
 		},
 		{
-			exclude: ["pnpm-lock.yaml"],
-			glob: yml.globs.all,
+			files: {
+				exclude: ["pnpm-lock.yaml"],
+				include: yml.files!.all,
+			},
 			rules: [yml.presets.logical],
 		},
 	],

--- a/packages/core/src/globs/all.ts
+++ b/packages/core/src/globs/all.ts
@@ -1,0 +1,19 @@
+import { FilesComputer, FilesGlobObject } from "../types/files.js";
+import { flatten } from "../utils/arrays.js";
+import { collectFilesValues } from "./collectFilesValues.js";
+
+export const all: FilesComputer = (config): FilesGlobObject => {
+	const exclude = new Set<string>();
+	const include = new Set<string>();
+
+	for (const definition of config.use) {
+		if (definition.files) {
+			collectFilesValues(flatten(definition.files), exclude, include);
+		}
+	}
+
+	return {
+		exclude: Array.from(exclude),
+		include: Array.from(include),
+	};
+};

--- a/packages/core/src/globs/collectFilesValues.ts
+++ b/packages/core/src/globs/collectFilesValues.ts
@@ -1,0 +1,32 @@
+import { FilesValue } from "../types/files.js";
+import { flatten } from "../utils/arrays.js";
+
+export function collectFilesValues(
+	filesValues: FilesValue[],
+	exclude: Set<string>,
+	include: Set<string>,
+) {
+	for (const files of filesValues) {
+		switch (typeof files) {
+			case "function":
+				break;
+
+			case "string":
+				include.add(files);
+				break;
+
+			default:
+				for (const excluded of flatten(files.exclude)) {
+					if (typeof excluded === "string") {
+						exclude.add(excluded);
+					}
+				}
+				for (const included of flatten(files.include)) {
+					if (typeof included === "string") {
+						include.add(included);
+					}
+				}
+				break;
+		}
+	}
+}

--- a/packages/core/src/globs/index.ts
+++ b/packages/core/src/globs/index.ts
@@ -1,0 +1,3 @@
+import { all } from "./all.js";
+
+export const globs = { all };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export { writeToCache } from "./cache/writeToCache.js";
 export { defineConfig } from "./configs/defineConfig.js";
 export { isConfig } from "./configs/isConfig.js";
 export { runPrettier } from "./formatting/runPrettier.js";
+export { globs } from "./globs/index.js";
 export { createLanguage } from "./languages/createLanguage.js";
 export { createPlugin } from "./plugins/createPlugin.js";
 export { formatReportPrimary } from "./reporting/formatReportPrimary.js";

--- a/packages/core/src/running/runConfig.ts
+++ b/packages/core/src/running/runConfig.ts
@@ -2,15 +2,20 @@ import { makeAbsolute } from "@flint.fyi/utils";
 import { CachedFactory } from "cached-factory";
 import { debugForFile } from "debug-for-file";
 import * as fs from "node:fs/promises";
+import path from "node:path";
 
 import { readFromCache } from "../cache/readFromCache.js";
+import { collectFilesValues } from "../globs/collectFilesValues.js";
+import { AnyLevelDeep } from "../types/arrays.js";
 import {
 	ConfigRuleDefinition,
 	ConfigUseDefinition,
 	ProcessedConfigDefinition,
 } from "../types/configs.js";
+import { FilesGlobObjectProcessed, FilesValue } from "../types/files.js";
 import { AnyLanguage } from "../types/languages.js";
 import { FileResults, RunConfigResults } from "../types/linting.js";
+import { flatten } from "../utils/arrays.js";
 import { lintFile } from "./lintFile.js";
 import { readGitignore } from "./readGitignore.js";
 
@@ -20,7 +25,7 @@ export async function runConfig(
 	configDefinition: ProcessedConfigDefinition,
 ): Promise<RunConfigResults> {
 	interface ConfigUseDefinitionWithFiles extends ConfigUseDefinition {
-		files: Set<string>;
+		found: Set<string>;
 		rules: ConfigRuleDefinition[];
 	}
 
@@ -30,25 +35,35 @@ export async function runConfig(
 	log("Excluding based on .gitignore: %s", gitignore);
 
 	const useDefinitions: ConfigUseDefinitionWithFiles[] = await Promise.all(
-		configDefinition.use.map(async (use) => ({
-			...use,
-			files: new Set(
-				await Array.fromAsync(
-					fs.glob([use.glob].flat() as string[], {
-						exclude: [
-							gitignore,
-							...(configDefinition.ignore ?? []),
-							...(use.exclude ?? []),
-						].flat(),
-					}),
+		configDefinition.use.map(async (use) => {
+			const globs = resolveUseFilesGlobs(use.files, configDefinition);
+
+			return {
+				...use,
+				found: new Set(
+					(
+						await Array.fromAsync(
+							fs.glob([globs.include].flat(), {
+								exclude: [...gitignore, ...globs.exclude],
+								withFileTypes: true,
+							}),
+						)
+					)
+						.filter((entry) => entry.isFile())
+						.map((entry) =>
+							path.relative(
+								process.cwd(),
+								makeAbsolute(path.join(entry.parentPath, entry.name)),
+							),
+						),
 				),
-			),
-			rules: (use.rules?.flat() ?? []) as ConfigRuleDefinition[],
-		})),
+				rules: use.rules ? flatten(use.rules) : [],
+			};
+		}),
 	);
 
-	const allFilePaths = new Set(
-		useDefinitions.flatMap((use) => Array.from(use.files)),
+	const allFoundPaths = new Set(
+		useDefinitions.flatMap((use) => Array.from(use.found)),
 	);
 	const filesResults = new Map<string, FileResults>();
 	let totalReports = 0;
@@ -57,21 +72,20 @@ export async function runConfig(
 		return language.prepare();
 	});
 
-	const cached = await readFromCache(allFilePaths, configDefinition.filePath);
+	const cached = await readFromCache(allFoundPaths, configDefinition.filePath);
 
 	// TODO: This is very slow and the whole thing should be refactored 🙌.
 	// The separate lintFile function recomputes rule options repeatedly.
-	// It'd be better to group files together in some way.
 	// It'd be better to group found files together in some way.
 	// Plus, this does an await in a for loop - should it use a queue?
-	for (const filePath of allFilePaths) {
+	for (const filePath of allFoundPaths) {
 		const { dependencies, diagnostics, reports } =
 			cached?.get(filePath) ??
 			(await lintFile(
 				makeAbsolute(filePath),
 				languageFactories,
 				useDefinitions
-					.filter((use) => use.files.has(filePath))
+					.filter((use) => use.found.has(filePath))
 					.flatMap((use) => use.rules),
 			));
 
@@ -88,5 +102,42 @@ export async function runConfig(
 
 	log("Found %d report(s)", totalReports);
 
-	return { allFilePaths, cached, filesResults };
+	return { allFilePaths: allFoundPaths, cached, filesResults };
+}
+
+function collectUseFilesGlobsObject(
+	files: AnyLevelDeep<FilesValue> | undefined,
+	configDefinition: ProcessedConfigDefinition,
+): FilesGlobObjectProcessed {
+	switch (typeof files) {
+		case "function":
+			return resolveUseFilesGlobs(files(configDefinition), configDefinition);
+
+		case "undefined":
+			return { exclude: [], include: [] };
+
+		default: {
+			const exclude = new Set<string>();
+			const include = new Set<string>();
+
+			collectFilesValues(flatten(files), exclude, include);
+
+			return {
+				exclude: Array.from(exclude),
+				include: Array.from(include),
+			};
+		}
+	}
+}
+
+function resolveUseFilesGlobs(
+	files: AnyLevelDeep<FilesValue> | undefined,
+	configDefinition: ProcessedConfigDefinition,
+): FilesGlobObjectProcessed {
+	const globs = collectUseFilesGlobsObject(files, configDefinition);
+
+	return {
+		exclude: [...globs.exclude, ...(configDefinition.ignore ?? [])],
+		include: globs.include,
+	};
 }

--- a/packages/core/src/types/arrays.ts
+++ b/packages/core/src/types/arrays.ts
@@ -1,3 +1,3 @@
 // TODO: How to get this allowing infinite depth?
 // https://github.com/JoshuaKGoldberg/flint/issues/182
-export type AnyLevelDeep<T> = AnyLevelDeep<T>[] | T;
+export type AnyLevelDeep<T> = T | T[] | T[][] | T[][][] | T[][][][];

--- a/packages/core/src/types/arrays.ts
+++ b/packages/core/src/types/arrays.ts
@@ -1,0 +1,2 @@
+// TODO: How to get this allowing infinite depth?
+export type AnyLevelDeep<T> = T | T[] | T[][] | T[][][];

--- a/packages/core/src/types/arrays.ts
+++ b/packages/core/src/types/arrays.ts
@@ -1,2 +1,3 @@
 // TODO: How to get this allowing infinite depth?
-export type AnyLevelDeep<T> = T | T[] | T[][] | T[][][] | T[][][][];
+// https://github.com/JoshuaKGoldberg/flint/issues/182
+export type AnyLevelDeep<T> = AnyLevelDeep<T>[] | T;

--- a/packages/core/src/types/arrays.ts
+++ b/packages/core/src/types/arrays.ts
@@ -1,2 +1,2 @@
 // TODO: How to get this allowing infinite depth?
-export type AnyLevelDeep<T> = T | T[] | T[][] | T[][][];
+export type AnyLevelDeep<T> = T | T[] | T[][] | T[][][] | T[][][][];

--- a/packages/core/src/types/configs.ts
+++ b/packages/core/src/types/configs.ts
@@ -1,6 +1,6 @@
+import { AnyLevelDeep } from "./arrays.js";
+import { FilesValue } from "./files.js";
 import { AnyRule } from "./rules.js";
-
-export type AnyLevelArray<T> = AnyLevelArray<T>[] | T[];
 
 export interface Config {
 	definition: ConfigDefinition;
@@ -22,9 +22,8 @@ export interface ConfigRuleDefinitionObject {
 }
 
 export interface ConfigUseDefinition {
-	exclude?: string[];
-	glob: AnyLevelArray<string> | string;
-	rules?: AnyLevelArray<ConfigRuleDefinition>;
+	files?: AnyLevelDeep<FilesValue>;
+	rules?: AnyLevelDeep<ConfigRuleDefinition>;
 }
 
 /**

--- a/packages/core/src/types/files.ts
+++ b/packages/core/src/types/files.ts
@@ -1,0 +1,22 @@
+import { AnyLevelDeep } from "./arrays.js";
+import { ProcessedConfigDefinition } from "./configs.js";
+
+export type FilesComputer = (
+	config: ProcessedConfigDefinition,
+) => FilesValuePrimitive;
+
+export interface FilesGlobObject {
+	exclude: AnyLevelDeep<FilesValue>;
+	include: AnyLevelDeep<FilesValue>;
+}
+
+export interface FilesGlobObjectProcessed {
+	exclude: string[];
+	include: string[];
+}
+
+export type FilesValue = FilesComputer | FilesValuePrimitive;
+
+export type FilesValuePrimitive = FilesGlobObject | string;
+
+export type FilesValues = AnyLevelDeep<FilesValue>;

--- a/packages/core/src/types/plugins.ts
+++ b/packages/core/src/types/plugins.ts
@@ -1,12 +1,13 @@
+import { FilesValue } from "./files.js";
 import { AnyRule, Rule, RuleAbout } from "./rules.js";
 import { AnyOptionalSchema, InferredObject } from "./shapes.js";
 
 export interface Plugin<
 	About extends RuleAbout,
-	Globs extends Record<string, string[]> | undefined,
+	FilesKey extends string | undefined,
 	Rules extends AnyRule<About>[],
 > {
-	globs: Globs;
+	files: FilesKey extends string ? Record<FilesKey, FilesValue> : undefined;
 	name: string;
 	presets: PluginPresets<About, Rules[number]["about"]["preset"]>;
 	rules: PluginRulesFactory<Rules>;

--- a/packages/core/src/utils/arrays.ts
+++ b/packages/core/src/utils/arrays.ts
@@ -1,0 +1,9 @@
+import { AnyLevelDeep } from "../types/arrays.js";
+
+export function flatten<T>(values: AnyLevelDeep<T>): T[] {
+	if (!Array.isArray(values)) {
+		return [values];
+	}
+
+	return values.flat(Infinity) as T[];
+}

--- a/packages/json/src/plugin.ts
+++ b/packages/json/src/plugin.ts
@@ -3,7 +3,7 @@ import { createPlugin } from "@flint.fyi/core";
 import duplicateKeys from "./rules/duplicateKeys.js";
 
 export const json = createPlugin({
-	globs: {
+	files: {
 		all: ["**/*.json"],
 	},
 	name: "json",

--- a/packages/md/src/plugin.ts
+++ b/packages/md/src/plugin.ts
@@ -3,7 +3,7 @@ import { createPlugin } from "@flint.fyi/core";
 import headingIncrements from "./rules/headingIncrements.js";
 
 export const md = createPlugin({
-	globs: {
+	files: {
 		all: ["**/*.md"],
 	},
 	name: "md",

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -5,7 +5,7 @@ import forInArrays from "./rules/forInArrays.js";
 import namespaceDeclarations from "./rules/namespaceDeclarations.js";
 
 export const ts = createPlugin({
-	globs: {
+	files: {
 		all: ["**/*.{cjs,js,jsx,mjs,ts,tsx}"],
 	},
 	name: "ts",

--- a/packages/yml/src/plugin.ts
+++ b/packages/yml/src/plugin.ts
@@ -3,7 +3,7 @@ import { createPlugin } from "@flint.fyi/core";
 import emptyMappingKeys from "./rules/emptyMappingKeys.js";
 
 export const yml = createPlugin({
-	globs: {
+	files: {
 		all: ["**/*.{yaml,yml}"],
 	},
 	name: "md",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #175
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Overhauls how configs exclude and include files. Previously there were `exclude` and `glob` properties. But being able to do something like `globs.all` need to be able to factor in past exclusions, not just inclusions.

Now, the two are merged into a `files` property that can be any of:

* `AnyLevelDeep<string>`: to act as glob includes
* An object with `exclude` and `include` properties
* A function to generate either

The function form takes in the `config: ProcessedConfigDefinition` that users specified. So `globs.all` just accumulates the `exclude`s and `include`s present in the config.

❤️‍🔥