### PR TITLE
tooling(#186): hex code enums for detailed presenter

### DIFF
--- a/packages/cli/src/presenters/detailed/constants.ts
+++ b/packages/cli/src/presenters/detailed/constants.ts
@@ -1,3 +1,18 @@
 import chalk from "chalk";
 
 export const indenter = chalk.gray("│ ");
+
+export enum colorCodes {
+	codeLineNumbers = "#bbb",
+	codeWarningUnderline = "#fcc",
+	defaultSuggestionColor = "#bbccdd",
+	filePath = "#ff4949",
+	filePathPrefix = "#ff7777",
+	primaryMessage = "#eeaa77",
+	reportAboutId = "#ff9999",
+	ruleBracket = "#ccaaaa",
+	ruleUrl = "#aaccaa",
+	secondaryMessage = "#ccbbaa",
+	suggestionMessage = "#99aacc",
+	suggestionTextHighlight = "#bbeeff",
+}

--- a/packages/cli/src/presenters/detailed/createDetailedReport.ts
+++ b/packages/cli/src/presenters/detailed/createDetailedReport.ts
@@ -1,7 +1,7 @@
 import { FileRuleReport } from "@flint.fyi/core";
 import chalk from "chalk";
 
-import { indenter } from "./constants.js";
+import { colorCodes, indenter } from "./constants.js";
 import { formatCode } from "./formatCode.js";
 import { formatSuggestion } from "./formatSuggestion.js";
 import { wrapIfNeeded } from "./wrapIfNeeded.js";
@@ -16,13 +16,13 @@ export async function* createDetailedReport(
 
 	yield indenter;
 	yield wrapIfNeeded(
-		chalk.hex("#eeaa77"),
+		chalk.hex(colorCodes.primaryMessage),
 		[
-			chalk.hex("#ccaaaa")("["),
+			chalk.hex(colorCodes.ruleBracket)("["),
 			chalk
-				.hex("#ff9999")
+				.hex(colorCodes.reportAboutId)
 				.bold(`\u001b]8;;${url}\u0007${report.about.id}\u001b]8;;\u0007`),
-			chalk.hex("#ccaaaa")("]"),
+			chalk.hex(colorCodes.ruleBracket)("]"),
 			" ",
 			report.message.primary,
 		].join(""),
@@ -36,7 +36,7 @@ export async function* createDetailedReport(
 	yield indenter;
 	yield " ";
 	yield wrapIfNeeded(
-		chalk.hex("#ccbbaa").italic,
+		chalk.hex(colorCodes.secondaryMessage).italic,
 		report.message.secondary.join(`\n`),
 		width,
 	);
@@ -44,19 +44,19 @@ export async function* createDetailedReport(
 
 	if (report.message.suggestions.length > 1) {
 		yield indenter;
-		yield chalk.hex("#bbeeff")(" Suggestions:");
+		yield chalk.hex(colorCodes.suggestionTextHighlight)(" Suggestions:");
 		yield "\n";
 		yield* report.message.suggestions.map((suggestion) =>
 			[
 				indenter,
-				chalk.hex("#99aacc")("  • "),
+				chalk.hex(colorCodes.suggestionMessage)("  • "),
 				formatSuggestion(suggestion),
 			].join("\n"),
 		);
 	} else {
 		yield `${indenter} `;
 		yield wrapIfNeeded(
-			chalk.hex("#bbeeff"),
+			chalk.hex(colorCodes.suggestionTextHighlight),
 			`  Suggestion: ${formatSuggestion(report.message.suggestions[0])}`,
 			width,
 		);
@@ -65,6 +65,6 @@ export async function* createDetailedReport(
 
 	yield `${indenter} `;
 	yield chalk
-		.hex("#aaccaa")
+		.hex(colorCodes.ruleUrl)
 		.italic(`→ \u001b]8;;${url}\u0007${urlFriendly}\u001b]8;;\u0007`);
 }

--- a/packages/cli/src/presenters/detailed/detailedPresenterFactory.ts
+++ b/packages/cli/src/presenters/detailed/detailedPresenterFactory.ts
@@ -5,7 +5,7 @@ import { presentHeader } from "../shared/header.js";
 import { presentDiagnostics } from "../shared/presentDiagnostics.js";
 import { presentSummary } from "../shared/summary.js";
 import { PresenterFactory } from "../types.js";
-import { indenter } from "./constants.js";
+import { colorCodes, indenter } from "./constants.js";
 import { createDetailedReport } from "./createDetailedReport.js";
 import { wrapIfNeeded } from "./wrapIfNeeded.js";
 
@@ -26,8 +26,12 @@ export const detailedPresenterFactory: PresenterFactory = {
 				const width = process.stdout.columns - indenter.length;
 
 				yield chalk.gray("╭");
-				yield chalk.hex("ff7777")("./");
-				yield* wrapIfNeeded(chalk.bold.hex("ff4949"), file.filePath, width);
+				yield chalk.hex(colorCodes.filePathPrefix)("./");
+				yield* wrapIfNeeded(
+					chalk.bold.hex(colorCodes.filePath),
+					file.filePath,
+					width,
+				);
 
 				let widest = 16;
 

--- a/packages/cli/src/presenters/detailed/formatCode.ts
+++ b/packages/cli/src/presenters/detailed/formatCode.ts
@@ -3,7 +3,7 @@ import * as shikiCli from "@shikijs/cli";
 import chalk from "chalk";
 import { styleText } from "node:util";
 
-import { indenter } from "./constants.js";
+import { colorCodes, indenter } from "./constants.js";
 
 // TODO: make reactive
 const leftWidth = 7;
@@ -26,14 +26,14 @@ export async function formatCode(
 
 	return [
 		indenter,
-		chalk.hex("bbb")(`${start} `.padStart(leftWidth - 2)),
+		chalk.hex(colorCodes.codeLineNumbers)(`${start} `.padStart(leftWidth - 2)),
 		chalk.gray("│ "),
 		highlightedLines.join(styleText("gray", "     │ ")),
 		"\n",
 		indenter,
 		chalk.gray("│ ".padStart(leftWidth)),
 		" ".repeat(report.range.begin.column),
-		chalk.hex("#fcc")(
+		chalk.hex(colorCodes.codeWarningUnderline)(
 			"~".repeat(report.range.end.column - report.range.begin.column),
 		),
 	].join("");

--- a/packages/cli/src/presenters/detailed/formatSuggestion.ts
+++ b/packages/cli/src/presenters/detailed/formatSuggestion.ts
@@ -1,12 +1,18 @@
 import chalk from "chalk";
 
+import { colorCodes } from "./constants.js";
+
 export function formatSuggestion(suggestion: string) {
 	return [
-		chalk.hex("#bbccdd")(
+		chalk.hex(colorCodes.defaultSuggestionColor)(
 			suggestion
 				.split("`")
 				.map((text, index) =>
-					chalk.hex(index % 2 === 0 ? "#bbccdd" : "#bbeeff")(text),
+					chalk.hex(
+						index % 2 === 0
+							? colorCodes.defaultSuggestionColor
+							: colorCodes.suggestionTextHighlight,
+					)(text),
 				)
 				.join("`"),
 		),


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #186 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Added enum for hex codes used in detailed presenter files and refactored files to use this enum
