### PR TITLE
feat(core): add initial object structure for suggestions

### DIFF
--- a/packages/core/src/types/reports.ts
+++ b/packages/core/src/types/reports.ts
@@ -1,6 +1,7 @@
 import { Fix } from "./fixes.js";
 import { CharacterReportRange, ColumnAndLine } from "./ranges.js";
 import { RuleAbout } from "./rules.js";
+import { Suggestion } from "./suggestions.js";
 
 export interface FileRuleReport extends NormalizedRuleReport {
 	about: RuleAbout;
@@ -39,8 +40,8 @@ export type ReportInterpolationData = Record<string, boolean | number | string>;
 export interface RuleReport<Message extends string = string> {
 	data?: ReportInterpolationData;
 	fix?: Fix;
-
 	message: Message;
+	suggestions?: Suggestion[];
 
 	/**
 	 * Which specific characters in the source file are affected by this report.

--- a/packages/core/src/types/suggestions.ts
+++ b/packages/core/src/types/suggestions.ts
@@ -1,9 +1,9 @@
 import { CharacterReportRange } from "./ranges.js";
 
 /**
- * A "fix" (safe text change) to be made to a file.
+ * A "suggestion" (potentially unsafe text change) to be made to a file.
  */
-export interface Fix {
+export interface Suggestion {
 	/**
 	 * Range of text in the file to be updated.
 	 */


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #54
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds the initial `suggestions?: Suggestion[]` to `context.report`. As noted in #190, this isn't actually used anywhere yet.

❤️‍🔥