### PR TITLE
feat: allow rules to indicate dependencies

### DIFF
--- a/.changeset/bright-bats-sleep.md
+++ b/.changeset/bright-bats-sleep.md
@@ -1,0 +1,12 @@
+---
+"@flint.fyi/plugin-cspell": patch
+"@flint.fyi/plugin-flint": patch
+"@flint.fyi/core": patch
+"@flint.fyi/json": patch
+"@flint.fyi/text": patch
+"@flint.fyi/yml": patch
+"@flint.fyi/md": patch
+"@flint.fyi/ts": patch
+---
+
+allow rules to indicate dependencies

--- a/packages/core/src/running/lintFile.ts
+++ b/packages/core/src/running/lintFile.ts
@@ -49,12 +49,18 @@ export async function lintFile(
 		const ruleReports = await file.runRule(rule, options as object | undefined);
 		log("Found %d reports from rule %s", ruleReports.length, rule.about.id);
 
-		reports.push(
-			...ruleReports.map((report) => ({
+		for (const ruleReport of ruleReports) {
+			reports.push({
 				about: rule.about,
-				...report,
-			})),
-		);
+				...ruleReport,
+			});
+
+			if (ruleReport.dependencies) {
+				for (const dependency of ruleReport.dependencies) {
+					dependencies.add(dependency);
+				}
+			}
+		}
 	}
 
 	for (const [language, file] of languageFiles.entries()) {

--- a/packages/core/src/types/reports.ts
+++ b/packages/core/src/types/reports.ts
@@ -1,5 +1,4 @@
-import { Fix } from "./changes.js";
-import { Suggestion } from "./changes.js";
+import { Fix, Suggestion } from "./changes.js";
 import { CharacterReportRange, ColumnAndLine } from "./ranges.js";
 import { RuleAbout } from "./rules.js";
 
@@ -23,6 +22,12 @@ export interface NormalizedReportRangeObject {
  */
 export interface NormalizedRuleReport {
 	data?: ReportInterpolationData;
+
+	/**
+	 * Any files that should be factored into caching this report.
+	 */
+	dependencies?: string[];
+
 	fix?: Fix;
 	message: ReportMessageData;
 	range: NormalizedReportRangeObject;
@@ -40,6 +45,12 @@ export type ReportInterpolationData = Record<string, boolean | number | string>;
  */
 export interface RuleReport<Message extends string = string> {
 	data?: ReportInterpolationData;
+
+	/**
+	 * Any files that should be factored into caching this report.
+	 */
+	dependencies?: string[];
+
 	fix?: Fix;
 	message: Message;
 	suggestions?: Suggestion[];

--- a/packages/core/src/types/rules.ts
+++ b/packages/core/src/types/rules.ts
@@ -82,6 +82,11 @@ export interface RuleDefinition<
 	>;
 }
 
+export interface RuleRuntime<AstNodesByName> {
+	dependencies?: string[];
+	visitors?: RuleVisitors<AstNodesByName>;
+}
+
 export type RuleSetup<
 	AstNodesByName,
 	ContextServices extends object,
@@ -90,7 +95,7 @@ export type RuleSetup<
 > = (
 	context: ContextServices & RuleContext<MessageId>,
 	options: Options,
-) => PromiseOrSync<RuleVisitors<AstNodesByName> | undefined>;
+) => PromiseOrSync<RuleRuntime<AstNodesByName> | undefined>;
 
 export type RuleVisitor<ASTNode> = (node: ASTNode) => void;
 

--- a/packages/json/src/createJsonFile.ts
+++ b/packages/json/src/createJsonFile.ts
@@ -31,11 +31,13 @@ export function createTypeScriptJsonFile(
 				sourceFile,
 			};
 
-			const visitors = await rule.setup(context, options);
+			const runtime = await rule.setup(context, options);
 
-			if (!visitors) {
+			if (!runtime?.visitors) {
 				return reports;
 			}
+
+			const { visitors } = runtime;
 
 			const visit = (node: ts.Node) => {
 				visitors[ts.SyntaxKind[node.kind]]?.(node);

--- a/packages/md/src/createMarkdownFile.ts
+++ b/packages/md/src/createMarkdownFile.ts
@@ -55,12 +55,13 @@ export function createMarkdownFile(
 				root,
 			};
 
-			const visitors = await rule.setup(context, options);
+			const runtime = await rule.setup(context, options);
 
-			if (!visitors) {
+			if (!runtime?.visitors) {
 				return reports;
 			}
 
+			const { visitors } = runtime;
 			visit(root, (node) => {
 				visitors[node.type]?.(node);
 			});

--- a/packages/md/src/rules/headingIncrements.ts
+++ b/packages/md/src/rules/headingIncrements.ts
@@ -17,24 +17,26 @@ export default markdownLanguage.createRule({
 		let previousDepth = 0;
 
 		return {
-			heading(node) {
-				if (previousDepth && node.depth > previousDepth + 1) {
-					const begin = node.position.start.offset;
+			visitors: {
+				heading(node) {
+					if (previousDepth && node.depth > previousDepth + 1) {
+						const begin = node.position.start.offset;
 
-					context.report({
-						data: {
-							level: node.depth,
-							previous: previousDepth,
-						},
-						message: "levelSkip",
-						range: {
-							begin,
-							end: begin + node.depth,
-						},
-					});
-				}
+						context.report({
+							data: {
+								level: node.depth,
+								previous: previousDepth,
+							},
+							message: "levelSkip",
+							range: {
+								begin,
+								end: begin + node.depth,
+							},
+						});
+					}
 
-				previousDepth = node.depth;
+					previousDepth = node.depth;
+				},
 			},
 		};
 	},

--- a/packages/plugin-cspell/src/rules/spelling.ts
+++ b/packages/plugin-cspell/src/rules/spelling.ts
@@ -24,25 +24,29 @@ export default textLanguage.createRule({
 		}
 
 		return {
-			file(text) {
-				const issues = documentValidator.checkText(
-					[0, text.length],
-					undefined,
-					undefined,
-				);
+			dependencies: ["cspell.json"],
+			visitors: {
+				file: (text) => {
+					const issues = documentValidator.checkText(
+						[0, text.length],
+						undefined,
+						undefined,
+					);
 
-				for (const issue of issues) {
-					context.report({
-						data: {
-							word: issue.text,
-						},
-						message: "issue",
-						range: {
-							begin: issue.offset,
-							end: issue.offset + (issue.length ?? issue.text.length),
-						},
-					});
-				}
+					for (const issue of issues) {
+						context.report({
+							data: {
+								word: issue.text,
+							},
+							// dependencies: ["cspell.json"],
+							message: "issue",
+							range: {
+								begin: issue.offset,
+								end: issue.offset + (issue.length ?? issue.text.length),
+							},
+						});
+					}
+				},
 			},
 		};
 	},

--- a/packages/plugin-flint/src/rules/duplicateTestCases.ts
+++ b/packages/plugin-flint/src/rules/duplicateTestCases.ts
@@ -43,14 +43,16 @@ export default typescriptLanguage.createRule({
 		}
 
 		return {
-			CallExpression(node) {
-				const describedCases = getRuleTesterDescribedCases(node);
-				if (!describedCases) {
-					return;
-				}
+			visitors: {
+				CallExpression(node) {
+					const describedCases = getRuleTesterDescribedCases(node);
+					if (!describedCases) {
+						return;
+					}
 
-				checkTestCases(describedCases.invalid);
-				checkTestCases(describedCases.valid);
+					checkTestCases(describedCases.invalid);
+					checkTestCases(describedCases.valid);
+				},
 			},
 		};
 	},

--- a/packages/text/src/createTextFile.ts
+++ b/packages/text/src/createTextFile.ts
@@ -34,15 +34,15 @@ export function createTextFile(
 				sourceText,
 			};
 
-			const visitors = await rule.setup(context, options);
+			const runtime = await rule.setup(context, options);
 
-			if (visitors) {
-				visitors.file?.(sourceText);
+			if (runtime?.visitors) {
+				runtime.visitors.file?.(sourceText);
 
-				if (visitors.line) {
+				if (runtime.visitors.line) {
 					const lines = sourceText.split(/\r\n|\n|\r/);
 					for (const line of lines) {
-						visitors.line(line);
+						runtime.visitors.line(line);
 					}
 				}
 			}

--- a/packages/ts/src/createTypeScriptFileFromProgram.ts
+++ b/packages/ts/src/createTypeScriptFileFromProgram.ts
@@ -57,12 +57,13 @@ export function createTypeScriptFileFromProgram(
 				typeChecker: program.getTypeChecker(),
 			};
 
-			const visitors = await rule.setup(context, options);
+			const runtime = await rule.setup(context, options);
 
-			if (!visitors) {
+			if (!runtime?.visitors) {
 				return reports;
 			}
 
+			const { visitors } = runtime;
 			const visit = (node: ts.Node) => {
 				visitors[ts.SyntaxKind[node.kind]]?.(node);
 

--- a/packages/ts/src/rules/consecutiveNonNullAssertions.ts
+++ b/packages/ts/src/rules/consecutiveNonNullAssertions.ts
@@ -19,24 +19,26 @@ export default typescriptLanguage.createRule({
 	},
 	setup(context) {
 		return {
-			NonNullExpression(node) {
-				if (node.parent.kind !== ts.SyntaxKind.NonNullExpression) {
-					return;
-				}
+			visitors: {
+				NonNullExpression: (node) => {
+					if (node.parent.kind !== ts.SyntaxKind.NonNullExpression) {
+						return;
+					}
 
-				const range = {
-					begin: node.end,
-					end: node.parent.end + 1,
-				};
+					const range = {
+						begin: node.end,
+						end: node.parent.end + 1,
+					};
 
-				context.report({
-					fix: {
+					context.report({
+						fix: {
+							range,
+							text: "",
+						},
+						message: "consecutiveNonNullAssertion",
 						range,
-						text: "",
-					},
-					message: "consecutiveNonNullAssertion",
-					range,
-				});
+					});
+				},
 			},
 		};
 	},

--- a/packages/ts/src/rules/forInArrays.ts
+++ b/packages/ts/src/rules/forInArrays.ts
@@ -46,21 +46,23 @@ export default typescriptLanguage.createRule({
 		}
 
 		return {
-			ForInStatement(node) {
-				const type = getConstrainedTypeAtLocation(
-					node.expression,
-					context.typeChecker,
-				);
+			visitors: {
+				ForInStatement: (node) => {
+					const type = getConstrainedTypeAtLocation(
+						node.expression,
+						context.typeChecker,
+					);
 
-				if (isArrayLike(type)) {
-					context.report({
-						message: "forIn",
-						range: {
-							begin: node.getStart(),
-							end: node.statement.getStart() - 1,
-						},
-					});
-				}
+					if (isArrayLike(type)) {
+						context.report({
+							message: "forIn",
+							range: {
+								begin: node.getStart(),
+								end: node.statement.getStart() - 1,
+							},
+						});
+					}
+				},
 			},
 		};
 	},

--- a/packages/ts/src/rules/namespaceDeclarations.ts
+++ b/packages/ts/src/rules/namespaceDeclarations.ts
@@ -32,26 +32,31 @@ export default typescriptLanguage.createRule({
 		}
 
 		return {
-			ModuleDeclaration(node) {
-				if (
-					node.parent.kind !== ts.SyntaxKind.SourceFile ||
-					node.name.kind !== ts.SyntaxKind.Identifier ||
-					node.name.text === "global"
-				) {
-					return;
-				}
+			visitors: {
+				ModuleDeclaration: (node) => {
+					if (
+						node.parent.kind !== ts.SyntaxKind.SourceFile ||
+						node.name.kind !== ts.SyntaxKind.Identifier ||
+						node.name.text === "global"
+					) {
+						return;
+					}
 
-				if (
-					allowDeclarations &&
-					tsutils.includesModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword)
-				) {
-					return;
-				}
+					if (
+						allowDeclarations &&
+						tsutils.includesModifier(
+							node.modifiers,
+							ts.SyntaxKind.DeclareKeyword,
+						)
+					) {
+						return;
+					}
 
-				context.report({
-					message: "preferModules",
-					range: getTSNodeRange(node.getChildAt(0), context.sourceFile),
-				});
+					context.report({
+						message: "preferModules",
+						range: getTSNodeRange(node.getChildAt(0), context.sourceFile),
+					});
+				},
 			},
 		};
 	},

--- a/packages/yml/src/createYamlFile.ts
+++ b/packages/yml/src/createYamlFile.ts
@@ -54,11 +54,13 @@ export function createYamlFile(
 				root,
 			};
 
-			const visitors = await rule.setup(context, options);
+			const runtime = await rule.setup(context, options);
 
-			if (!visitors) {
+			if (!runtime?.visitors) {
 				return reports;
 			}
+
+			const { visitors } = runtime;
 
 			visit(root, (node) => {
 				visitors[node.type]?.(node);

--- a/packages/yml/src/rules/emptyMappingKeys.ts
+++ b/packages/yml/src/rules/emptyMappingKeys.ts
@@ -14,16 +14,18 @@ export default ymlLanguage.createRule({
 	},
 	setup(context) {
 		return {
-			mappingKey(node) {
-				if (node.children.length === 0) {
-					context.report({
-						message: "emptyKey",
-						range: {
-							begin: node.position.start.offset,
-							end: node.position.end.offset + 1,
-						},
-					});
-				}
+			visitors: {
+				mappingKey: (node) => {
+					if (node.children.length === 0) {
+						context.report({
+							message: "emptyKey",
+							range: {
+								begin: node.position.start.offset,
+								end: node.position.end.offset + 1,
+							},
+						});
+					}
+				},
 			},
 		};
 	},


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #202
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Previously, rule setup functions directly returned the rule visitor record. That's what ESLint and most other linters do. This switches the structure to put them under `visitors`, so that a sibling `dependencies` can be returned too.

Also takes in a style suggestion from @dimitropoulos of switching the visitors from methods to property functions. A lot of new-to-rules people I'd introduced struggled with methods syntax. I'd toyed with this over the years but never got around to seriously doing it.

❤️‍🔥