### PR TITLE
docs: add 'Equivalents in Other Linters' tables to rules

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -1,21 +1,727 @@
-{
-	"abbreviations": {
+[
+	{
+		"biome": [
+			{ "name": "noAlert", "url": "https://biomejs.dev/linter/rules/noAlert" }
+		],
 		"eslint": [
 			{
-				"name": "unicorn/prevent-abbreviations",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prevent-abbreviations.md"
+				"name": "no-alert",
+				"url": "https://eslint.org/docs/latest/rules/no-alert"
 			}
 		],
 		"flint": {
-			"name": "abbreviations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"name": "browserAlerts",
+			"plugin": { "code": "browser", "name": "Browser" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "eslint/no-alert",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-alert.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/prefer-classlist-toggle",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-classlist-toggle.md"
+			}
+		],
+		"flint": {
+			"name": "classListToggles",
+			"plugin": { "code": "browser", "name": "Browser" },
+			"preset": "Stylistic",
+			"strictness": "Strict"
+		}
+	},
+	{
+		"biome": [
+			{
+				"name": "noDocumentCookie",
+				"url": "https://biomejs.dev/linter/rules/noDocumentCookie"
+			}
+		],
+		"eslint": [
+			{
+				"name": "unicorn/no-document-cookie",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-document-cookie.md"
+			}
+		],
+		"flint": {
+			"name": "documentCookies",
+			"plugin": { "code": "browser", "name": "Browser" },
+			"preset": "Logical",
+			"strictness": "Strict"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/no-document-cookie",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-document-cookie.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/prefer-event-target",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-event-target.md"
+			}
+		],
+		"flint": {
+			"name": "eventClasses",
+			"plugin": { "code": "browser", "name": "Browser" },
+			"preset": "Logical",
+			"strictness": "Strict"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/prefer-event-target",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-event-target.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/prefer-add-event-listener",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-add-event-listener.md"
+			}
+		],
+		"flint": {
+			"name": "eventListenerSubscriptions",
+			"plugin": { "code": "browser", "name": "Browser" },
+			"preset": "Logical",
+			"strictness": "Strict"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/prefer-add-event-listener",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-add-event-listener.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "no-implicit-globals",
+				"url": "https://eslint.org/docs/latest/rules/no-implicit-globals"
+			}
+		],
+		"flint": {
+			"name": "implicitGlobals",
+			"plugin": { "code": "browser", "name": "Browser" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/prefer-keyboard-event-key",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-keyboard-event-key.md"
+			}
+		],
+		"flint": {
+			"name": "keyboardEventKeys",
+			"plugin": { "code": "browser", "name": "Browser" },
+			"preset": "Not implementing"
+		},
+		"notes": "Superseded by deprecated"
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/prefer-dom-node-append",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-append.md"
+			}
+		],
+		"flint": {
+			"name": "nodeAppendMethods",
+			"plugin": { "code": "browser", "name": "Browser" },
+			"preset": "Logical",
+			"strictness": "Strict"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/prefer-dom-node-append",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-dom-node-append.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/prefer-dom-node-dataset",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-dataset.md"
+			}
+		],
+		"flint": {
+			"name": "nodeDatasetAttributes",
+			"plugin": { "code": "browser", "name": "Browser" },
+			"preset": "Logical",
+			"strictness": "Strict"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/prefer-dom-node-dataset",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-dom-node-dataset.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/prefer-modern-dom-apis",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-modern-dom-apis.md"
+			}
+		],
+		"flint": {
+			"name": "nodeModificationMethods",
+			"plugin": { "code": "browser", "name": "Browser" },
+			"preset": "Logical",
+			"strictness": "Strict"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/prefer-modern-dom-apis",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-modern-dom-apis.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/prefer-query-selector",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-query-selector.md"
+			}
+		],
+		"flint": {
+			"name": "nodeQueryMethods",
+			"plugin": { "code": "browser", "name": "Browser" },
+			"preset": "Stylistic",
+			"strictness": "Strict"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/prefer-query-selector",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-query-selector.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/prefer-dom-node-remove",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-remove.md"
+			}
+		],
+		"flint": {
+			"name": "nodeRemoveMethods",
+			"plugin": { "code": "browser", "name": "Browser" },
+			"preset": "Logical",
+			"strictness": "Strict"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/prefer-dom-node-remove",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-dom-node-remove.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/prefer-dom-node-text-content",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-text-content.md"
+			}
+		],
+		"flint": {
+			"name": "nodeTextContents",
+			"plugin": { "code": "browser", "name": "Browser" },
+			"preset": "Logical",
+			"strictness": "Strict"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/prefer-dom-node-text-content",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-dom-node-text-content.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/no-invalid-remove-event-listener",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-invalid-remove-event-listener.md"
+			}
+		],
+		"flint": {
+			"name": "removeEventListenerExpressions",
+			"plugin": { "code": "browser", "name": "Browser" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/no-invalid-remove-event-listener",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-invalid-remove-event-listener.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "no-script-url",
+				"url": "https://eslint.org/docs/latest/rules/no-script-url"
+			}
+		],
+		"flint": {
+			"name": "scriptUrls",
+			"plugin": { "code": "browser", "name": "Browser" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "eslint/no-script-url",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-script-url.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/require-post-message-target-origin",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/require-post-message-target-origin.md"
+			}
+		],
+		"flint": {
+			"name": "windowMessagingTargetOrigin",
+			"plugin": { "code": "browser", "name": "Browser" },
+			"preset": "Not implementing"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/require-post-message-target-origin",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/require-post-message-target-origin.html"
+			}
+		]
+	},
+	{
+		"deno": [
+			{
+				"name": "prefer-ascii",
+				"url": "https://docs.deno.com/lint/rules/prefer-ascii"
+			}
+		],
+		"flint": {
+			"name": "asciiCharacters",
+			"plugin": { "code": "deno", "name": "Deno" },
 			"preset": "Not implementing"
 		}
 	},
-	"accessKeys": {
+	{
+		"deno": [
+			{
+				"name": "no-node-globals",
+				"url": "https://docs.deno.com/lint/rules/no-node-globals"
+			}
+		],
+		"flint": {
+			"name": "nodeGlobals",
+			"plugin": { "code": "deno", "name": "Deno" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"deno": [
+			{
+				"name": "no-sync-fn-in-async-fn",
+				"url": "https://docs.deno.com/lint/rules/no-sync-fn-in-async-fn"
+			}
+		],
+		"flint": {
+			"name": "syncFunctionInAsyncFunctions",
+			"plugin": { "code": "deno", "name": "Deno" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/sort-array-values",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/sort-array-values.html"
+			}
+		],
+		"flint": {
+			"name": "arrayElementsSorting",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-bigint-literals",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-bigint-literals.html"
+			}
+		],
+		"flint": {
+			"name": "bigintLiterals",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-binary-expression",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-binary-expression.html"
+			}
+		],
+		"flint": {
+			"name": "binaryExpressions",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-binary-numeric-literals",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-binary-numeric-literals.html"
+			}
+		],
+		"flint": {
+			"name": "binaryNumericLiterals",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-comments",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-comments.html"
+			}
+		],
+		"flint": {
+			"name": "comments",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-floating-decimal",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-floating-decimal.html"
+			}
+		],
+		"flint": {
+			"name": "floatingDecimals",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-hexadecimal-numeric-literals",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-hexadecimal-numeric-literals.html"
+			}
+		],
+		"flint": {
+			"name": "hexadecimalNumericLiterals",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-escape-sequence-in-identifier",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-escape-sequence-in-identifier.html"
+			}
+		],
+		"flint": {
+			"name": "identifierEscapeSequences",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-number-props",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-number-props.html"
+			}
+		],
+		"flint": {
+			"name": "identifierNumbers",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-infinity",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-infinity.html"
+			}
+		],
+		"flint": {
+			"name": "infinity",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/key-name-casing",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/key-name-casing.html"
+			}
+		],
+		"flint": {
+			"name": "keyCasing",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "json/no-empty-keys",
+				"url": "https://github.com/eslint/json/blob/main/docs/rules/no-empty-keys.md"
+			}
+		],
+		"flint": {
+			"name": "keyContents",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"deno": [
+			{
+				"name": "no-dupe-keys",
+				"url": "https://docs.deno.com/lint/rules/no-dupe-keys"
+			}
+		],
+		"eslint": [
+			{
+				"name": "jsonc/no-dupe-keys",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-dupe-keys.html"
+			}
+		],
+		"flint": {
+			"name": "keyDuplicates",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "json/no-unnormalized-keys",
+				"url": "https://github.com/eslint/json/blob/main/docs/rules/no-unnormalized-keys.md"
+			}
+		],
+		"flint": {
+			"name": "keyNormalization",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-nan",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-nan.html"
+			}
+		],
+		"flint": {
+			"name": "nan",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/valid-json-number",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/valid-json-number.html"
+			}
+		],
+		"flint": {
+			"name": "numbers",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-numeric-separators",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-numeric-separators.html"
+			}
+		],
+		"flint": {
+			"name": "numericSeparators",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-octal-escape",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-escape.html"
+			}
+		],
+		"flint": {
+			"name": "octalEscapeSequences",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-octal-escape",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-escape.html"
+			}
+		],
+		"flint": {
+			"name": "octalLiterals",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-octal-numeric-literals",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-numeric-literals.html"
+			}
+		],
+		"flint": {
+			"name": "octalNumericLiterals",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-parenthesized",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-parenthesized.html"
+			}
+		],
+		"flint": {
+			"name": "parentheses",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-plus-sign",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-plus-sign.html"
+			}
+		],
+		"flint": {
+			"name": "plusOperators",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-template-literals",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-template-literals.html"
+			}
+		],
+		"flint": {
+			"name": "templateLiterals",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "json/top-level-interop",
+				"url": "https://github.com/eslint/json/blob/main/docs/rules/top-level-interop.md"
+			}
+		],
+		"flint": {
+			"name": "topLevelInteroperability",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-undefined-value",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-undefined-value.html"
+			}
+		],
+		"flint": {
+			"name": "undefined",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-unicode-codepoint-escapes",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-unicode-codepoint-escapes.html"
+			}
+		],
+		"flint": {
+			"name": "unicodeCodepointEscapes",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Not implementing"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "json/no-unsafe-values",
+				"url": "https://github.com/eslint/json/blob/main/docs/rules/no-unsafe-values.md"
+			}
+		],
+		"flint": {
+			"name": "valueSafety",
+			"plugin": { "code": "json", "name": "JSON" },
+			"preset": "Logical"
+		}
+	},
+	{
 		"eslint": [
 			{
 				"name": "jsx-a11y/no-access-key",
@@ -24,10 +730,7 @@
 		],
 		"flint": {
 			"name": "accessKeys",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
+			"plugin": { "code": "jsx", "name": "JSX" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -37,46 +740,7 @@
 			}
 		]
 	},
-	"accessorPairs": {
-		"eslint": [
-			{
-				"name": "accessor-pairs",
-				"url": "https://eslint.org/docs/latest/rules/accessor-pairs"
-			}
-		],
-		"flint": {
-			"name": "accessorPairs",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"accessorThisRecursion": {
-		"eslint": [
-			{
-				"name": "unicorn/no-accessor-recursion",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-accessor-recursion.md"
-			}
-		],
-		"flint": {
-			"name": "accessorThisRecursion",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
-			"preset": "Logical",
-			"strictness": "Strict"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/no-accessor-recursion",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-accessor-recursion.html"
-			}
-		]
-	},
-	"altText": {
+	{
 		"eslint": [
 			{
 				"name": "jsx-a11y/alt-text",
@@ -85,10 +749,7 @@
 		],
 		"flint": {
 			"name": "altText",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
+			"plugin": { "code": "jsx", "name": "JSX" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -98,7 +759,7 @@
 			}
 		]
 	},
-	"anchorAmbiguousText": {
+	{
 		"eslint": [
 			{
 				"name": "jsx-a11y/anchor-ambiguous-text",
@@ -107,10 +768,7 @@
 		],
 		"flint": {
 			"name": "anchorAmbiguousText",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
+			"plugin": { "code": "jsx", "name": "JSX" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		},
@@ -121,7 +779,7 @@
 			}
 		]
 	},
-	"anchorContent": {
+	{
 		"eslint": [
 			{
 				"name": "jsx-a11y/anchor-content",
@@ -130,10 +788,7 @@
 		],
 		"flint": {
 			"name": "anchorContent",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
+			"plugin": { "code": "jsx", "name": "JSX" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -143,7 +798,7 @@
 			}
 		]
 	},
-	"anchorValidity": {
+	{
 		"eslint": [
 			{
 				"name": "jsx-a11y/anchor-is-valid",
@@ -152,10 +807,7 @@
 		],
 		"flint": {
 			"name": "anchorValidity",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
+			"plugin": { "code": "jsx", "name": "JSX" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -165,7 +817,2748 @@
 			}
 		]
 	},
-	"anyArguments": {
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/aria-activedescendant-has-tabindex",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-activedescendant-has-tabindex.md"
+			}
+		],
+		"flint": {
+			"name": "ariaActiveDescendantTabIndex",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/aria-activedescendant-has-tabindex",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/aria-activedescendant-has-tabindex.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/no-aria-hidden-on-focusable",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-aria-hidden-on-focusable.md"
+			}
+		],
+		"flint": {
+			"name": "ariaHiddenFocusables",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical",
+			"strictness": "Strict"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/no-aria-hidden-on-focusable",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/no-aria-hidden-on-focusable.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/aria-props",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-props.md"
+			}
+		],
+		"flint": {
+			"name": "ariaProps",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/aria-props",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/aria-props.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/aria-proptypes",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-proptypes.md"
+			}
+		],
+		"flint": {
+			"name": "ariaPropTypes",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/aria-role",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-role.md"
+			}
+		],
+		"flint": {
+			"name": "ariaRoles",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/aria-role",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/aria-role.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/aria-unsupported-elements",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-unsupported-elements.md"
+			}
+		],
+		"flint": {
+			"name": "ariaUnsupportedElements",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/aria-unsupported-elements",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/aria-unsupported-elements.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/autocomplete-valid",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/autocomplete-valid.md"
+			}
+		],
+		"flint": {
+			"name": "autocomplete",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/autocomplete-valid",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/autocomplete-valid.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/no-autofocus",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-autofocus.md"
+			}
+		],
+		"flint": {
+			"name": "autoFocusProps",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/no-autofocus",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/no-autofocus.html"
+			}
+		]
+	},
+	{
+		"deno": [
+			{
+				"name": "jsx-boolean-value",
+				"url": "https://docs.deno.com/lint/rules/jsx-boolean-value"
+			}
+		],
+		"flint": {
+			"name": "booleanValues",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"deno": [
+			{
+				"name": "jsx-curly-braces",
+				"url": "https://docs.deno.com/lint/rules/jsx-curly-braces"
+			}
+		],
+		"flint": {
+			"name": "bracedStatements",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"deno": [
+			{
+				"name": "button-has-type",
+				"url": "https://docs.deno.com/lint/rules/button-has-type"
+			},
+			{
+				"name": "jsx-button-has-type",
+				"url": "https://docs.deno.com/lint/rules/jsx-button-has-type"
+			}
+		],
+		"flint": {
+			"name": "buttonTypes",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"deno": [
+			{
+				"name": "jsx-no-children-prop",
+				"url": "https://docs.deno.com/lint/rules/jsx-no-children-prop"
+			}
+		],
+		"flint": {
+			"name": "childrenProps",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/click-events-have-key-events",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/click-events-have-key-events.md"
+			}
+		],
+		"flint": {
+			"name": "clickEventKeyEvents",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/click-events-have-key-events",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/click-events-have-key-events.html"
+			}
+		]
+	},
+	{
+		"deno": [
+			{
+				"name": "jsx-no-comment-text-nodes",
+				"url": "https://docs.deno.com/lint/rules/jsx-no-comment-text-nodes"
+			}
+		],
+		"flint": {
+			"name": "commentTextNodes",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/no-distracting-elements",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-distracting-elements.md"
+			}
+		],
+		"flint": {
+			"name": "distractingElements",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/no-distracting-elements",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/no-distracting-elements.html"
+			}
+		]
+	},
+	{
+		"deno": [
+			{
+				"name": "jsx-no-duplicate-props",
+				"url": "https://docs.deno.com/lint/rules/jsx-no-duplicate-props"
+			}
+		],
+		"flint": {
+			"name": "duplicateProps",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"deno": [
+			{
+				"name": "jsx-props-no-spread-multi",
+				"url": "https://docs.deno.com/lint/rules/jsx-props-no-spread-multi"
+			}
+		],
+		"flint": {
+			"name": "duplicateSpreads",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/heading-has-content",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/heading-has-content.md"
+			}
+		],
+		"flint": {
+			"name": "headingContents",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/html-has-lang",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/html-has-lang.md"
+			}
+		],
+		"flint": {
+			"name": "htmlLangs",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/html-has-lang",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/html-has-lang.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/iframe-has-title",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/iframe-has-title.md"
+			}
+		],
+		"flint": {
+			"name": "iframeTitles",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/iframe-has-title",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/iframe-has-title.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/img-redundant-alt",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/img-redundant-alt.md"
+			}
+		],
+		"flint": {
+			"name": "imageAltRedundancy",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/img-redundant-alt",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/img-redundant-alt.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/no-interactive-element-to-noninteractive-role",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-interactive-element-to-noninteractive-role.md"
+			}
+		],
+		"flint": {
+			"name": "interactiveElementNonInteractiveRoles",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/interactive-elements-focusable",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/interactive-elements-focusable.md"
+			}
+		],
+		"flint": {
+			"name": "interactiveElementsFocusable",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"deno": [
+			{ "name": "jsx-key", "url": "https://docs.deno.com/lint/rules/jsx-key" }
+		],
+		"flint": {
+			"name": "iterableKeys",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/label-has-associated-control",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/label-has-associated-control.md"
+			}
+		],
+		"flint": {
+			"name": "labelAssociatedControls",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/label-has-associated-control",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/label-has-associated-control.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/lang",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/lang.md"
+			}
+		],
+		"flint": {
+			"name": "langValidity",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical",
+			"strictness": "Strict"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/lang",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/lang.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/media-has-caption",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/media-has-caption.md"
+			}
+		],
+		"flint": {
+			"name": "mediaCaptions",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/media-has-caption",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/media-has-caption.html"
+			}
+		]
+	},
+	{
+		"biome": [
+			{
+				"name": "noSuspiciousSemicolonInJsx",
+				"url": "https://biomejs.dev/linter/rules/noSuspiciousSemicolonInJsx"
+			}
+		],
+		"flint": {
+			"name": "misleadingSemicolons",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/mouse-events-have-key-events",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/mouse-events-have-key-events.md"
+			}
+		],
+		"flint": {
+			"name": "mouseEventKeyEvents",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/mouse-events-have-key-events",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/mouse-events-have-key-events.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/no-noninteractive-element-interactions",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-element-interactions.md"
+			}
+		],
+		"flint": {
+			"name": "nonInteractiveElementInteractions",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/no-noninteractive-element-to-interactive-role",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-element-to-interactive-role.md"
+			}
+		],
+		"flint": {
+			"name": "nonInteractiveElementInteractiveRoles",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/no-noninteractive-tabindex",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-tabindex.md"
+			}
+		],
+		"flint": {
+			"name": "nonInteractiveElementTabIndexes",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/no-noninteractive-tabindex",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/no-noninteractive-tabindex.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/no-redundant-roles",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-redundant-roles.md"
+			}
+		],
+		"flint": {
+			"name": "roleRedundancies",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/no-redundant-roles",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/no-redundant-roles.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/role-has-required-aria-props",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/role-has-required-aria-props.md"
+			}
+		],
+		"flint": {
+			"name": "roleRequiredAriaProps",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/role-has-required-aria-props",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/role-has-required-aria-props.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/prefer-tag-over-role",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/prefer-tag-over-role.md"
+			}
+		],
+		"flint": {
+			"name": "roleTags",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical",
+			"strictness": "Strict"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/prefer-tag-over-role",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/prefer-tag-over-role.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/role-supports-aria-props",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/role-supports-aria-props.md"
+			}
+		],
+		"flint": {
+			"name": "ruleSupportedAriaProps",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/role-supports-aria-props",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/role-supports-aria-props.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/scope",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/scope.md"
+			}
+		],
+		"flint": {
+			"name": "scopeProps",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/scope",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/scope.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/no-static-element-interactions",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-static-element-interactions.md"
+			}
+		],
+		"flint": {
+			"name": "staticElementInteractions",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"biome": [
+			{
+				"name": "noSvgWithoutTitle",
+				"url": "https://biomejs.dev/linter/rules/noSvgWithoutTitle"
+			}
+		],
+		"flint": {
+			"name": "svgTitles",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsx-a11y/tabindex-no-positive",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/tabindex-no-positive.md"
+			}
+		],
+		"flint": {
+			"name": "tabIndexPositiveValues",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "jsx_a11y/tabindex-no-positive",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/tabindex-no-positive.html"
+			}
+		]
+	},
+	{
+		"deno": [
+			{
+				"name": "jsx-no-unescaped-entities",
+				"url": "https://docs.deno.com/lint/rules/jsx-no-unescaped-entities"
+			}
+		],
+		"flint": {
+			"name": "unescapedEntities",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"deno": [
+			{
+				"name": "jsx-no-useless-fragment",
+				"url": "https://docs.deno.com/lint/rules/jsx-no-useless-fragment"
+			}
+		],
+		"flint": {
+			"name": "unnecessaryFragments",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"deno": [
+			{
+				"name": "jsx-void-dom-elements-no-children",
+				"url": "https://docs.deno.com/lint/rules/jsx-void-dom-elements-no-children"
+			}
+		],
+		"flint": {
+			"name": "validElementChildren",
+			"plugin": { "code": "jsx", "name": "JSX" },
+			"preset": "Logical",
+			"strictness": "Strict"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/no-bare-urls",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-bare-urls.md"
+			}
+		],
+		"flint": {
+			"name": "bareUrls",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Stylistic",
+			"strictness": "Strict"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/no-empty-definitions",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-empty-definitions.md"
+			}
+		],
+		"flint": {
+			"name": "definitionContents",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/no-duplicate-definitions",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-duplicate-definitions.md"
+			}
+		],
+		"flint": {
+			"name": "definitionDuplicates",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/no-unused-definitions",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-unused-definitions.md"
+			}
+		],
+		"flint": {
+			"name": "definitionUses",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/no-space-in-emphasis",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-space-in-emphasis.md"
+			}
+		],
+		"flint": {
+			"name": "emphasisMarkerSpacing",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/fenced-code-language",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/fenced-code-language.md"
+			}
+		],
+		"flint": {
+			"name": "fencedCodeLanguages",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Stylistic",
+			"strictness": "Strict"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/no-duplicate-headings",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-duplicate-headings.md"
+			}
+		],
+		"flint": {
+			"name": "headingDuplicates",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Stylistic",
+			"strictness": "Strict"
+		},
+		"notes": "Enable with Markdownlint's siblings_only equivalent"
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/heading-increment",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/heading-increment.md"
+			}
+		],
+		"flint": {
+			"implemented": true,
+			"name": "headingIncrements",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/no-missing-atx-heading-space",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-missing-atx-heading-space.md"
+			}
+		],
+		"flint": {
+			"name": "headingSpaces",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Not implementing"
+		},
+		"notes": "I intend to write a Prettier plugin."
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/no-multiple-h1",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-multiple-h1.md"
+			}
+		],
+		"flint": {
+			"name": "headingsRootDuplicates",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Logical",
+			"strictness": "Strict"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/no-html",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-html.md"
+			}
+		],
+		"flint": {
+			"name": "html",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/require-alt-text",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/require-alt-text.md"
+			}
+		],
+		"flint": {
+			"name": "imageAltTexts",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/no-empty-images",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-empty-images.md"
+			}
+		],
+		"flint": {
+			"name": "imageContents",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/no-missing-label-refs",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-missing-label-refs.md"
+			}
+		],
+		"flint": {
+			"name": "labelReferences",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/no-invalid-label-refs",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-invalid-label-refs.md"
+			}
+		],
+		"flint": {
+			"name": "labelReferenceValidity",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/no-empty-links",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-empty-links.md"
+			}
+		],
+		"flint": {
+			"name": "linkContents",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/no-missing-link-fragments",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-missing-link-fragments.md"
+			}
+		],
+		"flint": {
+			"name": "linkFragments",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/no-reversed-media-syntax",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-reversed-media-syntax.md"
+			}
+		],
+		"flint": {
+			"name": "mediaSyntaxReversals",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/no-reference-like-url",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-reference-like-url.md"
+			}
+		],
+		"flint": {
+			"name": "referenceLikeUrls",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "markdown/table-column-count",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/table-column-count.md"
+			}
+		],
+		"flint": {
+			"name": "tableColumnCounts",
+			"plugin": { "code": "md", "name": "Markdown" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"biome": [
+			{
+				"name": "useNodeAssertStrict",
+				"url": "https://biomejs.dev/linter/rules/useNodeAssertStrict"
+			}
+		],
+		"flint": {
+			"name": "assertStrict",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/consistent-assert",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-assert.md"
+			}
+		],
+		"flint": {
+			"name": "assertStyles",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Stylistic"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/consistent-assert",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/consistent-assert.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/prefer-blob-reading-methods",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-blob-reading-methods.md"
+			}
+		],
+		"flint": {
+			"name": "blobReadingMethods",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Stylistic"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/prefer-blob-reading-methods",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-blob-reading-methods.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/no-new-buffer",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-new-buffer.md"
+			}
+		],
+		"flint": {
+			"name": "bufferAllocators",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/no-new-buffer",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-new-buffer.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/handle-callback-err",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/handle-callback-err.md"
+			}
+		],
+		"flint": {
+			"name": "callbackErrorHandling",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-callback-literal",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-callback-literal.md"
+			}
+		],
+		"flint": {
+			"name": "callbackErrorLiterals",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/callback-return",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/callback-return.md"
+			}
+		],
+		"flint": {
+			"name": "callbackReturns",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/no-console-spaces",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-console-spaces.md"
+			}
+		],
+		"flint": {
+			"name": "consoleSpaces",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Stylistic",
+			"strictness": "Strict"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/no-console-spaces",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-console-spaces.html"
+			}
+		]
+	},
+	{
+		"deno": [
+			{
+				"name": "no-deprecated-deno-api",
+				"url": "https://docs.deno.com/lint/rules/no-deprecated-deno-api"
+			}
+		],
+		"eslint": [
+			{
+				"name": "n/no-deprecated-api",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-deprecated-api.md"
+			}
+		],
+		"flint": {
+			"name": "deprecatedAPIs",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		},
+		"notes": "Superseded by deprecated"
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-exports-assign",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-exports-assign.md"
+			}
+		],
+		"flint": {
+			"name": "exportsAssignments",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "node/no-exports-assign",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/node/no-exports-assign.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/exports-style",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/exports-style.md"
+			}
+		],
+		"flint": {
+			"name": "exportsStyle",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		},
+		"notes": "CJS-specific"
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-extraneous-import",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-extraneous-import.md"
+			}
+		],
+		"flint": {
+			"name": "extraneousImports",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		},
+		"notes": "Superseded by Knip"
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-extraneous-require",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-extraneous-require.md"
+			}
+		],
+		"flint": {
+			"name": "extraneousRequires",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		},
+		"notes": "Superseded by Knip"
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/prefer-import-meta-properties",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-import-meta-properties.md"
+			}
+		],
+		"flint": {
+			"name": "filePathsFromImportMeta",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Stylistic",
+			"strictness": "Strict"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/prefer-json-parse-buffer",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-json-parse-buffer.md"
+			}
+		],
+		"flint": {
+			"name": "fileReadJSONBuffers",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Stylistic",
+			"strictness": "Strict"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/prefer-global/buffer",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
+			}
+		],
+		"flint": {
+			"name": "globalBuffer",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/prefer-global/console",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
+			}
+		],
+		"flint": {
+			"name": "globalConsole",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"biome": [
+			{
+				"name": "noProcessGlobal",
+				"url": "https://biomejs.dev/linter/rules/noProcessGlobal"
+			}
+		],
+		"deno": [
+			{
+				"name": "no-process-global",
+				"url": "https://docs.deno.com/lint/rules/no-process-global"
+			}
+		],
+		"eslint": [
+			{
+				"name": "n/prefer-global/process",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
+			}
+		],
+		"flint": {
+			"name": "globalProcess",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/prefer-global/text-decoder",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
+			}
+		],
+		"flint": {
+			"name": "globalTextDecoder",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/prefer-global/text-encoder",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
+			}
+		],
+		"flint": {
+			"name": "globalTextEncoder",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/prefer-global/url-search-params",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
+			}
+		],
+		"flint": {
+			"name": "globalURL",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/prefer-global/url-search-params",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
+			}
+		],
+		"flint": {
+			"name": "globalURLSearchParams",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/hashbang",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/hashbang.md"
+			}
+		],
+		"flint": {
+			"name": "hashbangs",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"biome": [
+			{
+				"name": "useImportExtensions",
+				"url": "https://biomejs.dev/linter/rules/useImportExtensions"
+			}
+		],
+		"deno": [
+			{
+				"name": "no-sloppy-imports",
+				"url": "https://docs.deno.com/lint/rules/no-sloppy-imports"
+			}
+		],
+		"eslint": [
+			{
+				"name": "n/file-extension-in-import",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/file-extension-in-import.md"
+			}
+		],
+		"flint": {
+			"name": "importFileExtensions",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "None"
+		},
+		"oxlint": [
+			{
+				"name": "import/extensions",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/extensions.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-missing-import",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-missing-import.md"
+			}
+		],
+		"flint": {
+			"name": "missingImports",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-missing-require",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-missing-require.md"
+			}
+		],
+		"flint": {
+			"name": "missingRequires",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-mixed-requires",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-mixed-requires.md"
+			}
+		],
+		"flint": {
+			"name": "mixedRequires",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		},
+		"notes": "Superseded by ESM and ordering rules"
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-new-requires",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-new-requires.md"
+			}
+		],
+		"flint": {
+			"name": "newRequires",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		},
+		"oxlint": [
+			{
+				"name": "node/no-new-require",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/node/no-new-require.html"
+			}
+		]
+	},
+	{
+		"biome": [
+			{
+				"name": "useNodejsImportProtocol",
+				"url": "https://biomejs.dev/linter/rules/useNodejsImportProtocol"
+			}
+		],
+		"eslint": [
+			{
+				"name": "import/enforce-node-protocol-usage",
+				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/enforce-node-protocol-usage.md"
+			},
+			{
+				"name": "n/prefer-node-protocol",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-node-protocol.md"
+			},
+			{
+				"name": "unicorn/prefer-node-protocol",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md"
+			}
+		],
+		"flint": {
+			"name": "nodeProtocols",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/prefer-node-protocol",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-node-protocol.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-path-concat",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-path-concat.md"
+			}
+		],
+		"flint": {
+			"name": "pathConcatenations",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-process-env",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-process-env.md"
+			}
+		],
+		"flint": {
+			"name": "processEnvs",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-process-exit",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-process-exit.md"
+			},
+			{
+				"name": "unicorn/no-process-exit",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-process-exit.md"
+			}
+		],
+		"flint": {
+			"name": "processExists",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/no-process-exit",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-process-exit.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/process-exit-as-throw",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/process-exit-as-throw.md"
+			}
+		],
+		"flint": {
+			"name": "processExitThrows",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "promise/no-callback-in-promise",
+				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/HEAD/docs/rules/no-callback-in-promise.md"
+			}
+		],
+		"flint": {
+			"name": "promiseCallbackFunctions",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		},
+		"oxlint": [
+			{
+				"name": "promise/no-callback-in-promise",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/promise/no-callback-in-promise.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/prefer-promises/dns",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-promises.md"
+			}
+		],
+		"flint": {
+			"name": "promisesDNS",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/prefer-promises/fs",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-promises.md"
+			}
+		],
+		"flint": {
+			"name": "promisesFS",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-restricted-require",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-restricted-require.md"
+			}
+		],
+		"flint": {
+			"name": "restrictedRequires",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-sync",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-sync.md"
+			}
+		],
+		"flint": {
+			"name": "synchronousMethods",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/global-require",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/global-require.md"
+			}
+		],
+		"flint": {
+			"name": "topLevelRequires",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		},
+		"notes": "CJS-specific"
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-unpublished-bin",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unpublished-bin.md"
+			}
+		],
+		"flint": {
+			"name": "unpublishedBins",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-unpublished-import",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unpublished-import.md"
+			}
+		],
+		"flint": {
+			"name": "unpublishedImports",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-unpublished-require",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unpublished-require.md"
+			}
+		],
+		"flint": {
+			"name": "unpublishedRequires",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-unsupported-features/es-builtins",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unsupported-features.md"
+			}
+		],
+		"flint": {
+			"name": "unsupportedGlobals",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-unsupported-features/node-builtins",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unsupported-features.md"
+			}
+		],
+		"flint": {
+			"name": "unsupportedNodeAPIs",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "n/no-unsupported-features/es-syntax",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unsupported-features.md"
+			}
+		],
+		"flint": {
+			"name": "unsupportedSyntax",
+			"plugin": { "code": "node", "name": "Node" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/require-author",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-author.md"
+			}
+		],
+		"flint": {
+			"name": "authorPresence",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "None"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-author",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-author.md"
+			}
+		],
+		"flint": {
+			"name": "authorValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-bin",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-bin.md"
+			}
+		],
+		"flint": {
+			"name": "binValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/require-bugs",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-bugs.md"
+			}
+		],
+		"flint": {
+			"name": "bugsPresence",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "None"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/require-bundleDependencies",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-bundleDependencies.md"
+			}
+		],
+		"flint": {
+			"name": "bundleDependenciesPresence",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "None"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-bundleDependencies",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-bundleDependencies.md"
+			}
+		],
+		"flint": {
+			"name": "bundleDependenciesValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-config",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-config.md"
+			}
+		],
+		"flint": {
+			"name": "configValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-cpu",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-cpu.md"
+			}
+		],
+		"flint": {
+			"name": "cpuValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/require-dependencies",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-dependencies.md"
+			}
+		],
+		"flint": {
+			"name": "dependenciesPresence",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "None"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-dependencies",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-dependencies.md"
+			}
+		],
+		"flint": {
+			"name": "dependenciesValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/restrict-dependency-ranges",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/restrict-dependency-ranges.md"
+			}
+		],
+		"flint": {
+			"name": "dependencyRanges",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "None"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/unique-dependencies",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/unique-dependencies.md"
+			}
+		],
+		"flint": {
+			"name": "dependencyUniqueness",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/require-description",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-description.md"
+			}
+		],
+		"flint": {
+			"name": "descriptionPresence",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-description",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-description.md"
+			}
+		],
+		"flint": {
+			"name": "descriptionValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/require-devDependencies",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-devDependencies.md"
+			}
+		],
+		"flint": {
+			"name": "devDependenciesPresence",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "None"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-devDependencies",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-devDependencies.md"
+			}
+		],
+		"flint": {
+			"name": "devDependenciesValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-directories",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-directories.md"
+			}
+		],
+		"flint": {
+			"name": "directoriesValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/no-empty-fields",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/no-empty-fields.md"
+			}
+		],
+		"flint": {
+			"name": "emptyFields",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/require-engines",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-engines.md"
+			}
+		],
+		"flint": {
+			"name": "enginesPresence",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "None"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-exports",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-exports.md"
+			}
+		],
+		"flint": {
+			"name": "exportsValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/require-files",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-files.md"
+			}
+		],
+		"flint": {
+			"name": "filesPresence",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "None"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/no-redundant-files",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/no-redundant-files.md"
+			}
+		],
+		"flint": {
+			"name": "filesRedundancy",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-files",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-files.md"
+			}
+		],
+		"flint": {
+			"name": "filesValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-homepage",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-homepage.md"
+			}
+		],
+		"flint": {
+			"name": "homepageValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/require-keywords",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-keywords.md"
+			}
+		],
+		"flint": {
+			"name": "keywordsPresence",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "None"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-keywords",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-keywords.md"
+			}
+		],
+		"flint": {
+			"name": "keywordsValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/license-required",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/license-required.md"
+			}
+		],
+		"flint": {
+			"name": "licenseRequired",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-license",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-license.md"
+			}
+		],
+		"flint": {
+			"name": "licenseValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-main",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-main.md"
+			}
+		],
+		"flint": {
+			"name": "mainValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-man",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-man.md"
+			}
+		],
+		"flint": {
+			"name": "manValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/require-name",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-name.md"
+			}
+		],
+		"flint": {
+			"name": "namePresence",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-name",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-name.md"
+			}
+		],
+		"flint": {
+			"name": "nameValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/require-optionalDependencies",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-optionalDependencies.md"
+			}
+		],
+		"flint": {
+			"name": "optionalDependenciesPresence",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "None"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-optionalDependencies",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-optionalDependencies.md"
+			}
+		],
+		"flint": {
+			"name": "optionalDependenciesValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-os",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-os.md"
+			}
+		],
+		"flint": {
+			"name": "osValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/require-peerDependencies",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-peerDependencies.md"
+			}
+		],
+		"flint": {
+			"name": "peerDependenciesPresence",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "None"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-peerDependencies",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-peerDependencies.md"
+			}
+		],
+		"flint": {
+			"name": "peerDependenciesValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-private",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-private.md"
+			}
+		],
+		"flint": {
+			"name": "privateValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/order-properties",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/order-properties.md"
+			}
+		],
+		"flint": {
+			"name": "propertyOrdering",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-publishConfig",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-publishConfig.md"
+			}
+		],
+		"flint": {
+			"name": "publishConfigValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-repository-directory",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-repository-directory.md"
+			}
+		],
+		"flint": {
+			"name": "repositoryDirectoryValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/repository-shorthand",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/repository-shorthand.md"
+			}
+		],
+		"flint": {
+			"name": "repositoryShorthand",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-repository",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-repository.md"
+			}
+		],
+		"flint": {
+			"name": "repositoryValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-scripts",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-scripts.md"
+			}
+		],
+		"flint": {
+			"name": "scriptsValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/require-type",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-type.md"
+			}
+		],
+		"flint": {
+			"name": "typePresence",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/type-required",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/type-required.md"
+			}
+		],
+		"flint": {
+			"name": "typeRequired",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/require-types",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-types.md"
+			}
+		],
+		"flint": {
+			"name": "typesPresence",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "None"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-type",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-type.md"
+			}
+		],
+		"flint": {
+			"name": "typeValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/require-version",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-version.md"
+			}
+		],
+		"flint": {
+			"name": "versionPresence",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-version",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-version.md"
+			}
+		],
+		"flint": {
+			"name": "versionValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/valid-workspaces",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-workspaces.md"
+			}
+		],
+		"flint": {
+			"name": "workspacesValidity",
+			"plugin": { "code": "package-json", "name": "PackageJSON" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"biome": [
+			{ "name": "noDelete", "url": "https://biomejs.dev/linter/rules/noDelete" }
+		],
+		"flint": {
+			"name": "deletes",
+			"plugin": { "code": "performance", "name": "Performance" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"biome": [
+			{
+				"name": "noDynamicNamespaceImportAccess",
+				"url": "https://biomejs.dev/linter/rules/noDynamicNamespaceImportAccess"
+			}
+		],
+		"flint": {
+			"name": "importedNamespaceDynamicAccesses",
+			"plugin": { "code": "performance", "name": "Performance" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"flint": {
+			"name": "mappedObjectSpreads",
+			"plugin": { "code": "performance", "name": "Performance" },
+			"preset": "Not implementing"
+		},
+		"oxlint": [
+			{
+				"name": "oxc/no-map-spread",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/oxc/no-map-spread.html"
+			}
+		]
+	},
+	{
+		"biome": [
+			{
+				"name": "noAccumulatingSpread",
+				"url": "https://biomejs.dev/linter/rules/noAccumulatingSpread"
+			}
+		],
+		"flint": {
+			"name": "spreadAccumulators",
+			"plugin": { "code": "performance", "name": "Performance" },
+			"preset": "Logical"
+		},
+		"oxlint": [
+			{
+				"name": "oxc/no-accumulating-spread",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/oxc/no-accumulating-spread.html"
+			}
+		]
+	},
+	{
+		"biome": [
+			{
+				"name": "useSortedClasses",
+				"url": "https://biomejs.dev/linter/rules/useSortedClasses"
+			}
+		],
+		"eslint": [
+			{
+				"name": "perfectionist/sort-classes",
+				"url": "https://perfectionist.dev/rules/sort-classes"
+			}
+		],
+		"flint": {
+			"name": "classes",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "perfectionist/sort-decorators",
+				"url": "https://perfectionist.dev/rules/sort-decorators"
+			}
+		],
+		"flint": {
+			"name": "decorators",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "perfectionist/sort-named-exports",
+				"url": "https://perfectionist.dev/rules/sort-named-exports"
+			}
+		],
+		"flint": {
+			"name": "exports",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "perfectionist/sort-heritage-clauses",
+				"url": "https://perfectionist.dev/rules/sort-heritage-clauses"
+			}
+		],
+		"flint": {
+			"name": "heritageClauses",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "perfectionist/sort-interfaces",
+				"url": "https://perfectionist.dev/rules/sort-interfaces"
+			}
+		],
+		"flint": {
+			"name": "interfaces",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "perfectionist/sort-intersection-types",
+				"url": "https://perfectionist.dev/rules/sort-intersection-types"
+			}
+		],
+		"flint": {
+			"name": "intersectionTypes",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsdoc/sort-tags",
+				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/sort-tags.md"
+			}
+		],
+		"flint": {
+			"name": "jsdocTags",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "json/sort-keys",
+				"url": "https://github.com/eslint/json/blob/main/docs/rules/sort-keys.md"
+			},
+			{
+				"name": "jsonc/sort-keys",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/sort-keys.html"
+			}
+		],
+		"flint": {
+			"name": "jsonKeys",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "perfectionist/sort-jsx-props",
+				"url": "https://perfectionist.dev/rules/sort-jsx-props"
+			}
+		],
+		"flint": {
+			"name": "jsxProps",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "perfectionist/sort-maps",
+				"url": "https://perfectionist.dev/rules/sort-maps"
+			}
+		],
+		"flint": {
+			"name": "maps",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "perfectionist/sort-modules",
+				"url": "https://perfectionist.dev/rules/sort-modules"
+			}
+		],
+		"flint": {
+			"name": "modules",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "sort-keys",
+				"url": "https://eslint.org/docs/latest/rules/sort-keys"
+			},
+			{
+				"name": "perfectionist/sort-objects",
+				"url": "https://perfectionist.dev/rules/sort-objects"
+			}
+		],
+		"flint": {
+			"name": "objects",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		},
+		"oxlint": [
+			{
+				"name": "eslint/sort-keys",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/sort-keys.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "perfectionist/sort-object-types",
+				"url": "https://perfectionist.dev/rules/sort-object-types"
+			}
+		],
+		"flint": {
+			"name": "objectTypes",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "package-json/sort-collections",
+				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/sort-collections.md"
+			}
+		],
+		"flint": {
+			"name": "packageCollections",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "regexp/sort-flags",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/sort-flags.html"
+			}
+		],
+		"flint": {
+			"name": "regexFlags",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "regexp/sort-alternatives",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/sort-alternatives.html"
+			}
+		],
+		"flint": {
+			"name": "regexLists",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "perfectionist/sort-sets",
+				"url": "https://perfectionist.dev/rules/sort-sets"
+			}
+		],
+		"flint": {
+			"name": "sets",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "perfectionist/sort-switch-case",
+				"url": "https://perfectionist.dev/rules/sort-switch-case"
+			}
+		],
+		"flint": {
+			"name": "switchCases",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "perfectionist/sort-union-types",
+				"url": "https://perfectionist.dev/rules/sort-union-types"
+			}
+		],
+		"flint": {
+			"name": "unionTypes",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "perfectionist/sort-variable-declarations",
+				"url": "https://perfectionist.dev/rules/sort-variable-declarations"
+			}
+		],
+		"flint": {
+			"name": "variableDeclarations",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "yml/sort-keys",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/sort-keys.html"
+			}
+		],
+		"flint": {
+			"name": "ymlKeys",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "yml/sort-sequence-values",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/sort-sequence-values.html"
+			}
+		],
+		"flint": {
+			"name": "ymlSequenceValues",
+			"plugin": { "code": "sorting", "name": "Sorting" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/prevent-abbreviations",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prevent-abbreviations.md"
+			}
+		],
+		"flint": {
+			"name": "abbreviations",
+			"plugin": { "code": "ts", "name": "TypeScript" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "accessor-pairs",
+				"url": "https://eslint.org/docs/latest/rules/accessor-pairs"
+			}
+		],
+		"flint": {
+			"name": "accessorPairs",
+			"plugin": { "code": "ts", "name": "TypeScript" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "unicorn/no-accessor-recursion",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-accessor-recursion.md"
+			}
+		],
+		"flint": {
+			"name": "accessorThisRecursion",
+			"plugin": { "code": "ts", "name": "TypeScript" },
+			"preset": "Logical",
+			"strictness": "Strict"
+		},
+		"oxlint": [
+			{
+				"name": "unicorn/no-accessor-recursion",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-accessor-recursion.html"
+			}
+		]
+	},
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unsafe-argument",
@@ -174,10 +3567,7 @@
 		],
 		"flint": {
 			"name": "anyArguments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -187,7 +3577,7 @@
 			}
 		]
 	},
-	"anyAssignments": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unsafe-assignment",
@@ -196,10 +3586,7 @@
 		],
 		"flint": {
 			"name": "anyAssignments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -209,7 +3596,7 @@
 			}
 		]
 	},
-	"anyCalls": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unsafe-call",
@@ -218,10 +3605,7 @@
 		],
 		"flint": {
 			"name": "anyCalls",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -231,7 +3615,7 @@
 			}
 		]
 	},
-	"anyMemberAccess": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unsafe-member-access",
@@ -240,10 +3624,7 @@
 		],
 		"flint": {
 			"name": "anyMemberAccess",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -253,7 +3634,7 @@
 			}
 		]
 	},
-	"anyReturns": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unsafe-return",
@@ -262,10 +3643,7 @@
 		],
 		"flint": {
 			"name": "anyReturns",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -275,7 +3653,7 @@
 			}
 		]
 	},
-	"arguments": {
+	{
 		"biome": [
 			{
 				"name": "noArguments",
@@ -290,10 +3668,7 @@
 		],
 		"flint": {
 			"name": "arguments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -303,13 +3678,10 @@
 			}
 		]
 	},
-	"argumentsArrayMethods": {
+	{
 		"flint": {
 			"name": "argumentsArrayMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -319,7 +3691,7 @@
 			}
 		]
 	},
-	"argumentsProperties": {
+	{
 		"eslint": [
 			{
 				"name": "no-caller",
@@ -328,10 +3700,7 @@
 		],
 		"flint": {
 			"name": "argumentsProperties",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -341,134 +3710,7 @@
 			}
 		]
 	},
-	"ariaActiveDescendantTabIndex": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/aria-activedescendant-has-tabindex",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-activedescendant-has-tabindex.md"
-			}
-		],
-		"flint": {
-			"name": "ariaActiveDescendantTabIndex",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/aria-activedescendant-has-tabindex",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/aria-activedescendant-has-tabindex.html"
-			}
-		]
-	},
-	"ariaHiddenFocusables": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/no-aria-hidden-on-focusable",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-aria-hidden-on-focusable.md"
-			}
-		],
-		"flint": {
-			"name": "ariaHiddenFocusables",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical",
-			"strictness": "Strict"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/no-aria-hidden-on-focusable",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/no-aria-hidden-on-focusable.html"
-			}
-		]
-	},
-	"ariaProps": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/aria-props",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-props.md"
-			}
-		],
-		"flint": {
-			"name": "ariaProps",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/aria-props",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/aria-props.html"
-			}
-		]
-	},
-	"ariaPropTypes": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/aria-proptypes",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-proptypes.md"
-			}
-		],
-		"flint": {
-			"name": "ariaPropTypes",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		}
-	},
-	"ariaRoles": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/aria-role",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-role.md"
-			}
-		],
-		"flint": {
-			"name": "ariaRoles",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/aria-role",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/aria-role.html"
-			}
-		]
-	},
-	"ariaUnsupportedElements": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/aria-unsupported-elements",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-unsupported-elements.md"
-			}
-		],
-		"flint": {
-			"name": "ariaUnsupportedElements",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/aria-unsupported-elements",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/aria-unsupported-elements.html"
-			}
-		]
-	},
-	"arrayCallbackReturns": {
+	{
 		"biome": [
 			{
 				"name": "useIterableCallbackReturn",
@@ -483,10 +3725,7 @@
 		],
 		"flint": {
 			"name": "arrayCallbackReturns",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -496,7 +3735,7 @@
 			}
 		]
 	},
-	"arrayConstructors": {
+	{
 		"biome": [
 			{
 				"name": "useArrayLiterals",
@@ -525,10 +3764,7 @@
 		],
 		"flint": {
 			"name": "arrayConstructors",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -542,7 +3778,7 @@
 			}
 		]
 	},
-	"arrayDeleteUnnecessaryCounts": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-unnecessary-array-splice-count",
@@ -551,14 +3787,11 @@
 		],
 		"flint": {
 			"name": "arrayDeleteUnnecessaryCounts",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"arrayDestructuringSparsity": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-unreadable-array-destructuring",
@@ -567,10 +3800,7 @@
 		],
 		"flint": {
 			"name": "arrayDestructuringSparsity",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -580,7 +3810,7 @@
 			}
 		]
 	},
-	"arrayElementDeletions": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-array-delete",
@@ -589,10 +3819,7 @@
 		],
 		"flint": {
 			"name": "arrayElementDeletions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -602,29 +3829,10 @@
 			}
 		]
 	},
-	"arrayElementsSorting": {
-		"eslint": [
-			{
-				"name": "jsonc/sort-array-values",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/sort-array-values.html"
-			}
-		],
-		"flint": {
-			"name": "arrayElementsSorting",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"arrayEmptyCallbackSlots": {
+	{
 		"flint": {
 			"name": "arrayEmptyCallbackSlots",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -634,7 +3842,7 @@
 			}
 		]
 	},
-	"arrayExistenceChecksConsistency": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/consistent-existence-index-check",
@@ -643,10 +3851,7 @@
 		],
 		"flint": {
 			"name": "arrayExistenceChecksConsistency",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -656,7 +3861,7 @@
 			}
 		]
 	},
-	"arrayFilteredFinds": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-array-find",
@@ -665,10 +3870,7 @@
 		],
 		"flint": {
 			"name": "arrayFilteredFinds",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -679,7 +3881,7 @@
 			}
 		]
 	},
-	"arrayFinds": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/prefer-find",
@@ -688,14 +3890,11 @@
 		],
 		"flint": {
 			"name": "arrayFinds",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"arrayFlatDepthMagicNumbers": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-magic-array-flat-depth",
@@ -704,10 +3903,7 @@
 		],
 		"flint": {
 			"name": "arrayFlatDepthMagicNumbers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -717,7 +3913,7 @@
 			}
 		]
 	},
-	"arrayFlatMapMethods": {
+	{
 		"biome": [
 			{
 				"name": "useFlatMap",
@@ -732,10 +3928,7 @@
 		],
 		"flint": {
 			"name": "arrayFlatMapMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -746,7 +3939,7 @@
 			}
 		]
 	},
-	"arrayFlatMethods": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-array-flat",
@@ -755,10 +3948,7 @@
 		],
 		"flint": {
 			"name": "arrayFlatMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -769,7 +3959,7 @@
 			}
 		]
 	},
-	"arrayFlatUnnecessaryDepths": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-unnecessary-array-flat-depth",
@@ -778,10 +3968,7 @@
 		],
 		"flint": {
 			"name": "arrayFlatUnnecessaryDepths",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -791,7 +3978,7 @@
 			}
 		]
 	},
-	"arrayIncludes": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/prefer-includes",
@@ -800,10 +3987,7 @@
 		],
 		"flint": {
 			"name": "arrayIncludes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -813,7 +3997,7 @@
 			}
 		]
 	},
-	"arrayIncludesMethods": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-includes",
@@ -822,15 +4006,12 @@
 		],
 		"flint": {
 			"name": "arrayIncludesMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"arrayIndexOfMethods": {
+	{
 		"biome": [
 			{
 				"name": "useIndexOf",
@@ -845,10 +4026,7 @@
 		],
 		"flint": {
 			"name": "arrayIndexOfMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -859,7 +4037,7 @@
 			}
 		]
 	},
-	"arrayJoinSeparators": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/require-array-join-separator",
@@ -868,10 +4046,7 @@
 		],
 		"flint": {
 			"name": "arrayJoinSeparators",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -881,16 +4056,13 @@
 			}
 		]
 	},
-	"arrayLoops": {
+	{
 		"biome": [
 			{
 				"name": "noForEach",
 				"url": "https://biomejs.dev/linter/rules/noForEach"
 			},
-			{
-				"name": "useForOf",
-				"url": "https://biomejs.dev/linter/rules/useForOf"
-			}
+			{ "name": "useForOf", "url": "https://biomejs.dev/linter/rules/useForOf" }
 		],
 		"eslint": [
 			{
@@ -908,10 +4080,7 @@
 		],
 		"flint": {
 			"name": "arrayLoops",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -925,7 +4094,7 @@
 			}
 		]
 	},
-	"arrayMapIdentities": {
+	{
 		"biome": [
 			{
 				"name": "noFlatMapIdentity",
@@ -934,14 +4103,11 @@
 		],
 		"flint": {
 			"name": "arrayMapIdentities",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"arrayMethodThisArguments": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-array-method-this-argument",
@@ -950,10 +4116,7 @@
 		],
 		"flint": {
 			"name": "arrayMethodThisArguments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -963,7 +4126,7 @@
 			}
 		]
 	},
-	"arrayMutableReverses": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-array-reverse",
@@ -972,14 +4135,11 @@
 		],
 		"flint": {
 			"name": "arrayMutableReverses",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"arrayMutableSorts": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-array-sort",
@@ -988,14 +4148,11 @@
 		],
 		"flint": {
 			"name": "arrayMutableSorts",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"arrayReducers": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-array-reduce",
@@ -1004,10 +4161,7 @@
 		],
 		"flint": {
 			"name": "arrayReducers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -1017,7 +4171,7 @@
 			}
 		]
 	},
-	"arraySliceUnnecessaryEnd": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-unnecessary-slice-end",
@@ -1026,10 +4180,7 @@
 		],
 		"flint": {
 			"name": "arraySliceUnnecessaryEnd",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -1043,7 +4194,7 @@
 			}
 		]
 	},
-	"arraySomeMethods": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-array-some",
@@ -1052,10 +4203,7 @@
 		],
 		"flint": {
 			"name": "arraySomeMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -1066,7 +4214,7 @@
 			}
 		]
 	},
-	"arraySortCompareArgument": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/require-array-sort-compare",
@@ -1075,10 +4223,7 @@
 		],
 		"flint": {
 			"name": "arraySortCompareArgument",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -1088,7 +4233,7 @@
 			}
 		]
 	},
-	"arrayTernarySpreadingConsistency": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/consistent-empty-array-spread",
@@ -1097,10 +4242,7 @@
 		],
 		"flint": {
 			"name": "arrayTernarySpreadingConsistency",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -1110,7 +4252,7 @@
 			}
 		]
 	},
-	"arrayTypes": {
+	{
 		"biome": [
 			{
 				"name": "useConsistentArrayType",
@@ -1125,10 +4267,7 @@
 		],
 		"flint": {
 			"name": "arrayTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -1138,7 +4277,7 @@
 			}
 		]
 	},
-	"arrayUnnecessaryLengthChecks": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-useless-length-check",
@@ -1147,10 +4286,7 @@
 		],
 		"flint": {
 			"name": "arrayUnnecessaryLengthChecks",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -1160,7 +4296,7 @@
 			}
 		]
 	},
-	"arrowBodyBraces": {
+	{
 		"eslint": [
 			{
 				"name": "arrow-body-style",
@@ -1169,10 +4305,7 @@
 		],
 		"flint": {
 			"name": "arrowBodyBraces",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -1182,7 +4315,7 @@
 			}
 		]
 	},
-	"arrowCallbacks": {
+	{
 		"biome": [
 			{
 				"name": "useArrowFunction",
@@ -1197,30 +4330,11 @@
 		],
 		"flint": {
 			"name": "arrowCallbacks",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"asciiCharacters": {
-		"deno": [
-			{
-				"name": "prefer-ascii",
-				"url": "https://docs.deno.com/lint/rules/prefer-ascii"
-			}
-		],
-		"flint": {
-			"name": "asciiCharacters",
-			"plugin": {
-				"code": "deno",
-				"name": "Deno"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"asConstAssertions": {
+	{
 		"biome": [
 			{
 				"name": "useAsConstAssertion",
@@ -1241,10 +4355,7 @@
 		],
 		"flint": {
 			"name": "asConstAssertions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -1254,51 +4365,10 @@
 			}
 		]
 	},
-	"assertStrict": {
-		"biome": [
-			{
-				"name": "useNodeAssertStrict",
-				"url": "https://biomejs.dev/linter/rules/useNodeAssertStrict"
-			}
-		],
-		"flint": {
-			"name": "assertStrict",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"assertStyles": {
-		"eslint": [
-			{
-				"name": "unicorn/consistent-assert",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-assert.md"
-			}
-		],
-		"flint": {
-			"name": "assertStyles",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Stylistic"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/consistent-assert",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/consistent-assert.html"
-			}
-		]
-	},
-	"assignmentOperationRefactors": {
+	{
 		"flint": {
 			"name": "assignmentOperationRefactors",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -1308,7 +4378,7 @@
 			}
 		]
 	},
-	"assignmentOperatorShorthands": {
+	{
 		"eslint": [
 			{
 				"name": "logical-assignment-operators",
@@ -1317,20 +4387,14 @@
 		],
 		"flint": {
 			"name": "assignmentOperatorShorthands",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"asyncAwaitStatements": {
+	{
 		"flint": {
 			"name": "asyncAwaitStatements",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -1340,12 +4404,9 @@
 			}
 		]
 	},
-	"asyncFunctionAwaits": {
+	{
 		"biome": [
-			{
-				"name": "useAwait",
-				"url": "https://biomejs.dev/linter/rules/useAwait"
-			}
+			{ "name": "useAwait", "url": "https://biomejs.dev/linter/rules/useAwait" }
 		],
 		"deno": [
 			{
@@ -1365,10 +4426,7 @@
 		],
 		"flint": {
 			"name": "asyncFunctionAwaits",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -1382,7 +4440,7 @@
 			}
 		]
 	},
-	"asyncPromiseExecutors": {
+	{
 		"biome": [
 			{
 				"name": "noAsyncPromiseExecutor",
@@ -1403,10 +4461,7 @@
 		],
 		"flint": {
 			"name": "asyncPromiseExecutors",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -1416,7 +4471,7 @@
 			}
 		]
 	},
-	"asyncUnnecessaryPromiseWrappers": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-useless-promise-resolve-reject",
@@ -1425,10 +4480,7 @@
 		],
 		"flint": {
 			"name": "asyncUnnecessaryPromiseWrappers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -1438,7 +4490,7 @@
 			}
 		]
 	},
-	"atAccesses": {
+	{
 		"biome": [
 			{
 				"name": "useAtIndex",
@@ -1453,15 +4505,12 @@
 		],
 		"flint": {
 			"name": "atAccesses",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"atomicUpdates": {
+	{
 		"eslint": [
 			{
 				"name": "require-atomic-updates",
@@ -1470,90 +4519,11 @@
 		],
 		"flint": {
 			"name": "atomicUpdates",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"authorPresence": {
-		"eslint": [
-			{
-				"name": "package-json/require-author",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-author.md"
-			}
-		],
-		"flint": {
-			"name": "authorPresence",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "None"
-		}
-	},
-	"authorValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-author",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-author.md"
-			}
-		],
-		"flint": {
-			"name": "authorValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"autocomplete": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/autocomplete-valid",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/autocomplete-valid.md"
-			}
-		],
-		"flint": {
-			"name": "autocomplete",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/autocomplete-valid",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/autocomplete-valid.html"
-			}
-		]
-	},
-	"autoFocusProps": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/no-autofocus",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-autofocus.md"
-			}
-		],
-		"flint": {
-			"name": "autoFocusProps",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/no-autofocus",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/no-autofocus.html"
-			}
-		]
-	},
-	"awaitInsidePromiseMethods": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-await-in-promise-methods",
@@ -1562,10 +4532,7 @@
 		],
 		"flint": {
 			"name": "awaitInsidePromiseMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		},
@@ -1576,7 +4543,7 @@
 			}
 		]
 	},
-	"awaitMemberAccesses": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-await-expression-member",
@@ -1585,10 +4552,7 @@
 		],
 		"flint": {
 			"name": "awaitMemberAccesses",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -1598,7 +4562,7 @@
 			}
 		]
 	},
-	"awaitThenable": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/await-thenable",
@@ -1611,10 +4575,7 @@
 		],
 		"flint": {
 			"name": "awaitThenable",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -1628,30 +4589,10 @@
 			}
 		]
 	},
-	"bareUrls": {
-		"eslint": [
-			{
-				"name": "markdown/no-bare-urls",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-bare-urls.md"
-			}
-		],
-		"flint": {
-			"name": "bareUrls",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Stylistic",
-			"strictness": "Strict"
-		}
-	},
-	"barrelFiles": {
+	{
 		"flint": {
 			"name": "barrelFiles",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -1661,80 +4602,10 @@
 			}
 		]
 	},
-	"bigintLiterals": {
-		"eslint": [
-			{
-				"name": "jsonc/no-bigint-literals",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-bigint-literals.html"
-			}
-		],
-		"flint": {
-			"name": "bigintLiterals",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"binaryExpressions": {
-		"eslint": [
-			{
-				"name": "jsonc/no-binary-expression",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-binary-expression.html"
-			}
-		],
-		"flint": {
-			"name": "binaryExpressions",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"binaryNumericLiterals": {
-		"eslint": [
-			{
-				"name": "jsonc/no-binary-numeric-literals",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-binary-numeric-literals.html"
-			}
-		],
-		"flint": {
-			"name": "binaryNumericLiterals",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"binValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-bin",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-bin.md"
-			}
-		],
-		"flint": {
-			"name": "binValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"bitwiseOperatorLogic": {
+	{
 		"flint": {
 			"name": "bitwiseOperatorLogic",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -1744,7 +4615,7 @@
 			}
 		]
 	},
-	"bitwiseOperators": {
+	{
 		"biome": [
 			{
 				"name": "noBitwiseOperators",
@@ -1759,10 +4630,7 @@
 		],
 		"flint": {
 			"name": "bitwiseOperators",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -1772,61 +4640,7 @@
 			}
 		]
 	},
-	"blobReadingMethods": {
-		"eslint": [
-			{
-				"name": "unicorn/prefer-blob-reading-methods",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-blob-reading-methods.md"
-			}
-		],
-		"flint": {
-			"name": "blobReadingMethods",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Stylistic"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/prefer-blob-reading-methods",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-blob-reading-methods.html"
-			}
-		]
-	},
-	"blockMappings": {
-		"eslint": [
-			{
-				"name": "yml/block-mapping",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/block-mapping.html"
-			}
-		],
-		"flint": {
-			"name": "blockMappings",
-			"plugin": {
-				"code": "yml",
-				"name": "YML"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"blockSequences": {
-		"eslint": [
-			{
-				"name": "yml/block-sequence",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/block-sequence.html"
-			}
-		],
-		"flint": {
-			"name": "blockSequences",
-			"plugin": {
-				"code": "yml",
-				"name": "YML"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"blockStatements": {
+	{
 		"biome": [
 			{
 				"name": "useBlockStatements",
@@ -1834,17 +4648,11 @@
 			}
 		],
 		"eslint": [
-			{
-				"name": "curly",
-				"url": "https://eslint.org/docs/latest/rules/curly"
-			}
+			{ "name": "curly", "url": "https://eslint.org/docs/latest/rules/curly" }
 		],
 		"flint": {
 			"name": "blockStatements",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing",
 			"strictness": "Strict"
 		},
@@ -1856,7 +4664,7 @@
 			}
 		]
 	},
-	"booleanLiteralParameterComments": {
+	{
 		"deno": [
 			{
 				"name": "no-boolean-literal-for-arguments",
@@ -1865,112 +4673,11 @@
 		],
 		"flint": {
 			"name": "booleanLiteralParameterComments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"booleanValues": {
-		"deno": [
-			{
-				"name": "jsx-boolean-value",
-				"url": "https://docs.deno.com/lint/rules/jsx-boolean-value"
-			}
-		],
-		"flint": {
-			"name": "booleanValues",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"bracedStatements": {
-		"deno": [
-			{
-				"name": "jsx-curly-braces",
-				"url": "https://docs.deno.com/lint/rules/jsx-curly-braces"
-			}
-		],
-		"flint": {
-			"name": "bracedStatements",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"browserAlerts": {
-		"biome": [
-			{
-				"name": "noAlert",
-				"url": "https://biomejs.dev/linter/rules/noAlert"
-			}
-		],
-		"eslint": [
-			{
-				"name": "no-alert",
-				"url": "https://eslint.org/docs/latest/rules/no-alert"
-			}
-		],
-		"flint": {
-			"name": "browserAlerts",
-			"plugin": {
-				"code": "browser",
-				"name": "Browser"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "eslint/no-alert",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-alert.html"
-			}
-		]
-	},
-	"bufferAllocators": {
-		"eslint": [
-			{
-				"name": "unicorn/no-new-buffer",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-new-buffer.md"
-			}
-		],
-		"flint": {
-			"name": "bufferAllocators",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/no-new-buffer",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-new-buffer.html"
-			}
-		]
-	},
-	"bugsPresence": {
-		"eslint": [
-			{
-				"name": "package-json/require-bugs",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-bugs.md"
-			}
-		],
-		"flint": {
-			"name": "bugsPresence",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "None"
-		}
-	},
-	"builtinCoercions": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-native-coercion-functions",
@@ -1979,10 +4686,7 @@
 		],
 		"flint": {
 			"name": "builtinCoercions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -1993,7 +4697,7 @@
 			}
 		]
 	},
-	"builtinConstructorNews": {
+	{
 		"biome": [
 			{
 				"name": "noInvalidBuiltinInstantiation",
@@ -2008,10 +4712,7 @@
 		],
 		"flint": {
 			"name": "builtinConstructorNews",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -2021,7 +4722,7 @@
 			}
 		]
 	},
-	"builtinPrototypeMethodAccesses": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-prototype-methods",
@@ -2030,10 +4731,7 @@
 		],
 		"flint": {
 			"name": "builtinPrototypeMethodAccesses",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing",
 			"strictness": "Strict"
 		},
@@ -2044,107 +4742,7 @@
 			}
 		]
 	},
-	"bundleDependenciesPresence": {
-		"eslint": [
-			{
-				"name": "package-json/require-bundleDependencies",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-bundleDependencies.md"
-			}
-		],
-		"flint": {
-			"name": "bundleDependenciesPresence",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "None"
-		}
-	},
-	"bundleDependenciesValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-bundleDependencies",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-bundleDependencies.md"
-			}
-		],
-		"flint": {
-			"name": "bundleDependenciesValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"buttonTypes": {
-		"deno": [
-			{
-				"name": "button-has-type",
-				"url": "https://docs.deno.com/lint/rules/button-has-type"
-			},
-			{
-				"name": "jsx-button-has-type",
-				"url": "https://docs.deno.com/lint/rules/jsx-button-has-type"
-			}
-		],
-		"flint": {
-			"name": "buttonTypes",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"callbackErrorHandling": {
-		"eslint": [
-			{
-				"name": "n/handle-callback-err",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/handle-callback-err.md"
-			}
-		],
-		"flint": {
-			"name": "callbackErrorHandling",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"callbackErrorLiterals": {
-		"eslint": [
-			{
-				"name": "n/no-callback-literal",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-callback-literal.md"
-			}
-		],
-		"flint": {
-			"name": "callbackErrorLiterals",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"callbackReturns": {
-		"eslint": [
-			{
-				"name": "n/callback-return",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/callback-return.md"
-			}
-		],
-		"flint": {
-			"name": "callbackReturns",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"capitalizedConstructors": {
+	{
 		"eslint": [
 			{
 				"name": "new-cap",
@@ -2153,10 +4751,7 @@
 		],
 		"flint": {
 			"name": "capitalizedConstructors",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -2166,7 +4761,7 @@
 			}
 		]
 	},
-	"caseDeclarations": {
+	{
 		"biome": [
 			{
 				"name": "noSwitchDeclarations",
@@ -2187,10 +4782,7 @@
 		],
 		"flint": {
 			"name": "caseDeclarations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -2200,7 +4792,7 @@
 			}
 		]
 	},
-	"caseDuplicates": {
+	{
 		"biome": [
 			{
 				"name": "noDuplicateCase",
@@ -2221,10 +4813,7 @@
 		],
 		"flint": {
 			"name": "caseDuplicates",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -2234,7 +4823,7 @@
 			}
 		]
 	},
-	"caseFallthroughs": {
+	{
 		"biome": [
 			{
 				"name": "noFallthroughSwitchClause",
@@ -2255,10 +4844,7 @@
 		],
 		"flint": {
 			"name": "caseFallthroughs",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -2268,7 +4854,7 @@
 			}
 		]
 	},
-	"catchCallbackTypes": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/use-unknown-in-catch-callback-variable",
@@ -2277,10 +4863,7 @@
 		],
 		"flint": {
 			"name": "catchCallbackTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -2290,7 +4873,7 @@
 			}
 		]
 	},
-	"caughtErrorCauses": {
+	{
 		"eslint": [
 			{
 				"name": "preserve-caught-error",
@@ -2299,15 +4882,12 @@
 		],
 		"flint": {
 			"name": "caughtErrorCauses",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		}
 	},
-	"caughtVariableNames": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/catch-error-name",
@@ -2316,10 +4896,7 @@
 		],
 		"flint": {
 			"name": "caughtVariableNames",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -2330,7 +4907,7 @@
 			}
 		]
 	},
-	"chainedAssignments": {
+	{
 		"eslint": [
 			{
 				"name": "no-multi-assign",
@@ -2339,10 +4916,7 @@
 		],
 		"flint": {
 			"name": "chainedAssignments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -2352,13 +4926,10 @@
 			}
 		]
 	},
-	"charAtComparisons": {
+	{
 		"flint": {
 			"name": "charAtComparisons",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -2368,23 +4939,7 @@
 			}
 		]
 	},
-	"childrenProps": {
-		"deno": [
-			{
-				"name": "jsx-no-children-prop",
-				"url": "https://docs.deno.com/lint/rules/jsx-no-children-prop"
-			}
-		],
-		"flint": {
-			"name": "childrenProps",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"classAssignments": {
+	{
 		"biome": [
 			{
 				"name": "noClassAssign",
@@ -2405,10 +4960,7 @@
 		],
 		"flint": {
 			"name": "classAssignments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -2418,29 +4970,7 @@
 			}
 		]
 	},
-	"classes": {
-		"biome": [
-			{
-				"name": "useSortedClasses",
-				"url": "https://biomejs.dev/linter/rules/useSortedClasses"
-			}
-		],
-		"eslint": [
-			{
-				"name": "perfectionist/sort-classes",
-				"url": "https://perfectionist.dev/rules/sort-classes"
-			}
-		],
-		"flint": {
-			"name": "classes",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"classFieldDeclarations": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-class-fields",
@@ -2449,32 +4979,12 @@
 		],
 		"flint": {
 			"name": "classFieldDeclarations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped",
 			"strictness": "Strict"
 		}
 	},
-	"classListToggles": {
-		"eslint": [
-			{
-				"name": "unicorn/prefer-classlist-toggle",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-classlist-toggle.md"
-			}
-		],
-		"flint": {
-			"name": "classListToggles",
-			"plugin": {
-				"code": "browser",
-				"name": "Browser"
-			},
-			"preset": "Stylistic",
-			"strictness": "Strict"
-		}
-	},
-	"classLiteralProperties": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/class-literal-property-style",
@@ -2483,14 +4993,11 @@
 		],
 		"flint": {
 			"name": "classLiteralProperties",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"classMemberDuplicates": {
+	{
 		"biome": [
 			{
 				"name": "noDuplicateClassMembers",
@@ -2515,10 +5022,7 @@
 		],
 		"flint": {
 			"name": "classMemberDuplicates",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -2528,7 +5032,7 @@
 			}
 		]
 	},
-	"classMethodsThis": {
+	{
 		"eslint": [
 			{
 				"name": "class-methods-use-this",
@@ -2541,37 +5045,12 @@
 		],
 		"flint": {
 			"name": "classMethodsThis",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"clickEventKeyEvents": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/click-events-have-key-events",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/click-events-have-key-events.md"
-			}
-		],
-		"flint": {
-			"name": "clickEventKeyEvents",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/click-events-have-key-events",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/click-events-have-key-events.html"
-			}
-		]
-	},
-	"combinedPushes": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-single-call",
@@ -2580,16 +5059,13 @@
 		],
 		"flint": {
 			"name": "combinedPushes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
 		"notes": "Just for Array#push(); the others would be their own rules"
 	},
-	"commentCapitalization": {
+	{
 		"eslint": [
 			{
 				"name": "capitalized-comments",
@@ -2598,47 +5074,11 @@
 		],
 		"flint": {
 			"name": "commentCapitalization",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"comments": {
-		"eslint": [
-			{
-				"name": "jsonc/no-comments",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-comments.html"
-			}
-		],
-		"flint": {
-			"name": "comments",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"commentTextNodes": {
-		"deno": [
-			{
-				"name": "jsx-no-comment-text-nodes",
-				"url": "https://docs.deno.com/lint/rules/jsx-no-comment-text-nodes"
-			}
-		],
-		"flint": {
-			"name": "commentTextNodes",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"commentWarnings": {
+	{
 		"eslint": [
 			{
 				"name": "no-warning-comments",
@@ -2647,25 +5087,19 @@
 		],
 		"flint": {
 			"name": "commentWarnings",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"comparisonSequences": {
+	{
 		"flint": {
 			"name": "comparisonSequences",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Handled by TypeScript / otherwise is stylistic"
 	},
-	"conditionalAssignments": {
+	{
 		"biome": [
 			{
 				"name": "noAssignInExpressions",
@@ -2686,10 +5120,7 @@
 		],
 		"flint": {
 			"name": "conditionalAssignments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Superseded by unnecessaryConditions",
@@ -2700,7 +5131,7 @@
 			}
 		]
 	},
-	"conditionNegations": {
+	{
 		"biome": [
 			{
 				"name": "noNegationElse",
@@ -2719,10 +5150,7 @@
 		],
 		"flint": {
 			"name": "conditionNegations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -2732,7 +5160,7 @@
 			}
 		]
 	},
-	"conditionOrdering": {
+	{
 		"biome": [
 			{
 				"name": "noYodaExpression",
@@ -2740,17 +5168,11 @@
 			}
 		],
 		"eslint": [
-			{
-				"name": "yoda",
-				"url": "https://eslint.org/docs/latest/rules/yoda"
-			}
+			{ "name": "yoda", "url": "https://eslint.org/docs/latest/rules/yoda" }
 		],
 		"flint": {
 			"name": "conditionOrdering",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -2760,23 +5182,7 @@
 			}
 		]
 	},
-	"configValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-config",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-config.md"
-			}
-		],
-		"flint": {
-			"name": "configValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"consecutiveNonNullAssertions": {
+	{
 		"biome": [
 			{
 				"name": "noExtraNonNullAssertion",
@@ -2798,10 +5204,7 @@
 		"flint": {
 			"implemented": true,
 			"name": "consecutiveNonNullAssertions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -2811,7 +5214,7 @@
 			}
 		]
 	},
-	"consistentReturns": {
+	{
 		"eslint": [
 			{
 				"name": "consistent-return",
@@ -2824,14 +5227,11 @@
 		],
 		"flint": {
 			"name": "consistentReturns",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"consoleCalls": {
+	{
 		"biome": [
 			{
 				"name": "noConsole",
@@ -2852,10 +5252,7 @@
 		],
 		"flint": {
 			"name": "consoleCalls",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "None"
 		},
 		"oxlint": [
@@ -2865,30 +5262,7 @@
 			}
 		]
 	},
-	"consoleSpaces": {
-		"eslint": [
-			{
-				"name": "unicorn/no-console-spaces",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-console-spaces.md"
-			}
-		],
-		"flint": {
-			"name": "consoleSpaces",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Stylistic",
-			"strictness": "Strict"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/no-console-spaces",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-console-spaces.html"
-			}
-		]
-	},
-	"constantAssignments": {
+	{
 		"biome": [
 			{
 				"name": "noConstAssign",
@@ -2909,10 +5283,7 @@
 		],
 		"flint": {
 			"name": "constantAssignments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -2922,7 +5293,7 @@
 			}
 		]
 	},
-	"constantBinaryExpressions": {
+	{
 		"biome": [
 			{
 				"name": "noConstantBinaryExpressions",
@@ -2937,10 +5308,7 @@
 		],
 		"flint": {
 			"name": "constantBinaryExpressions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Superseded by unnecessaryConditions",
@@ -2951,7 +5319,7 @@
 			}
 		]
 	},
-	"constantConditions": {
+	{
 		"biome": [
 			{
 				"name": "noConstantCondition",
@@ -2972,10 +5340,7 @@
 		],
 		"flint": {
 			"name": "constantConditions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Superseded by unnecessaryConditions",
@@ -2986,7 +5351,7 @@
 			}
 		]
 	},
-	"constEnums": {
+	{
 		"biome": [
 			{
 				"name": "noConstEnum",
@@ -2995,14 +5360,11 @@
 		],
 		"flint": {
 			"name": "constEnums",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"constructorReturns": {
+	{
 		"biome": [
 			{
 				"name": "noConstructorReturn",
@@ -3017,10 +5379,7 @@
 		],
 		"flint": {
 			"name": "constructorReturns",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "None"
 		},
 		"oxlint": [
@@ -3030,7 +5389,7 @@
 			}
 		]
 	},
-	"constructorSupers": {
+	{
 		"biome": [
 			{
 				"name": "noInvalidConstructorSuper",
@@ -3051,19 +5410,13 @@
 		],
 		"flint": {
 			"name": "constructorSupers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		}
 	},
-	"constVariables": {
+	{
 		"biome": [
-			{
-				"name": "useConst",
-				"url": "https://biomejs.dev/linter/rules/useConst"
-			}
+			{ "name": "useConst", "url": "https://biomejs.dev/linter/rules/useConst" }
 		],
 		"deno": [
 			{
@@ -3079,14 +5432,11 @@
 		],
 		"flint": {
 			"name": "constVariables",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"continues": {
+	{
 		"eslint": [
 			{
 				"name": "no-continue",
@@ -3095,10 +5445,7 @@
 		],
 		"flint": {
 			"name": "continues",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -3108,23 +5455,7 @@
 			}
 		]
 	},
-	"cpuValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-cpu",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-cpu.md"
-			}
-		],
-		"flint": {
-			"name": "cpuValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"dateConstructorClones": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/consistent-date-clone",
@@ -3133,15 +5464,12 @@
 		],
 		"flint": {
 			"name": "dateConstructorClones",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"notes": "unicorn/consistent-date-clone"
 	},
-	"dateNowTimestamps": {
+	{
 		"biome": [
 			{
 				"name": "useDateNow",
@@ -3156,10 +5484,7 @@
 		],
 		"flint": {
 			"name": "dateNowTimestamps",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		},
@@ -3170,7 +5495,7 @@
 			}
 		]
 	},
-	"debugger": {
+	{
 		"biome": [
 			{
 				"name": "noDebugger",
@@ -3191,10 +5516,7 @@
 		],
 		"flint": {
 			"name": "debugger",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -3204,23 +5526,7 @@
 			}
 		]
 	},
-	"decorators": {
-		"eslint": [
-			{
-				"name": "perfectionist/sort-decorators",
-				"url": "https://perfectionist.dev/rules/sort-decorators"
-			}
-		],
-		"flint": {
-			"name": "decorators",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"defaultCaseLast": {
+	{
 		"biome": [
 			{
 				"name": "useDefaultSwitchClauseLast",
@@ -3235,10 +5541,7 @@
 		],
 		"flint": {
 			"name": "defaultCaseLast",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -3248,7 +5551,7 @@
 			}
 		]
 	},
-	"defaultCases": {
+	{
 		"biome": [
 			{
 				"name": "useDefaultSwitchClause",
@@ -3263,10 +5566,7 @@
 		],
 		"flint": {
 			"name": "defaultCases",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -3276,7 +5576,7 @@
 			}
 		]
 	},
-	"defaultImportRenames": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-named-default",
@@ -3285,10 +5585,7 @@
 		],
 		"flint": {
 			"name": "defaultImportRenames",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -3306,7 +5603,7 @@
 			}
 		]
 	},
-	"defaultParameterLast": {
+	{
 		"biome": [
 			{
 				"name": "useDefaultParameterLast",
@@ -3331,10 +5628,7 @@
 		],
 		"flint": {
 			"name": "defaultParameterLast",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -3344,7 +5638,7 @@
 			}
 		]
 	},
-	"defaultParameterReassignments": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-default-parameters",
@@ -3353,142 +5647,11 @@
 		],
 		"flint": {
 			"name": "defaultParameterReassignments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"definitionContents": {
-		"eslint": [
-			{
-				"name": "markdown/no-empty-definitions",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-empty-definitions.md"
-			}
-		],
-		"flint": {
-			"name": "definitionContents",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Logical"
-		}
-	},
-	"definitionDuplicates": {
-		"eslint": [
-			{
-				"name": "markdown/no-duplicate-definitions",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-duplicate-definitions.md"
-			}
-		],
-		"flint": {
-			"name": "definitionDuplicates",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Logical"
-		}
-	},
-	"definitionUses": {
-		"eslint": [
-			{
-				"name": "markdown/no-unused-definitions",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-unused-definitions.md"
-			}
-		],
-		"flint": {
-			"name": "definitionUses",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Logical"
-		}
-	},
-	"deletes": {
-		"biome": [
-			{
-				"name": "noDelete",
-				"url": "https://biomejs.dev/linter/rules/noDelete"
-			}
-		],
-		"flint": {
-			"name": "deletes",
-			"plugin": {
-				"code": "performance",
-				"name": "Performance"
-			},
-			"preset": "Logical"
-		}
-	},
-	"dependenciesPresence": {
-		"eslint": [
-			{
-				"name": "package-json/require-dependencies",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-dependencies.md"
-			}
-		],
-		"flint": {
-			"name": "dependenciesPresence",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "None"
-		}
-	},
-	"dependenciesValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-dependencies",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-dependencies.md"
-			}
-		],
-		"flint": {
-			"name": "dependenciesValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"dependencyRanges": {
-		"eslint": [
-			{
-				"name": "package-json/restrict-dependency-ranges",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/restrict-dependency-ranges.md"
-			}
-		],
-		"flint": {
-			"name": "dependencyRanges",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "None"
-		}
-	},
-	"dependencyUniqueness": {
-		"eslint": [
-			{
-				"name": "package-json/unique-dependencies",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/unique-dependencies.md"
-			}
-		],
-		"flint": {
-			"name": "dependencyUniqueness",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"deprecated": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-deprecated",
@@ -3497,69 +5660,11 @@
 		],
 		"flint": {
 			"name": "deprecated",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"deprecatedAPIs": {
-		"deno": [
-			{
-				"name": "no-deprecated-deno-api",
-				"url": "https://docs.deno.com/lint/rules/no-deprecated-deno-api"
-			}
-		],
-		"eslint": [
-			{
-				"name": "n/no-deprecated-api",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-deprecated-api.md"
-			}
-		],
-		"flint": {
-			"name": "deprecatedAPIs",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Superseded by deprecated"
-	},
-	"descriptionPresence": {
-		"eslint": [
-			{
-				"name": "package-json/require-description",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-description.md"
-			}
-		],
-		"flint": {
-			"name": "descriptionPresence",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"descriptionValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-description",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-description.md"
-			}
-		],
-		"flint": {
-			"name": "descriptionValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"destructuring": {
+	{
 		"eslint": [
 			{
 				"name": "prefer-destructuring",
@@ -3572,10 +5677,7 @@
 		],
 		"flint": {
 			"name": "destructuring",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -3585,7 +5687,7 @@
 			}
 		]
 	},
-	"destructuringConsistency": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/consistent-destructuring",
@@ -3594,47 +5696,12 @@
 		],
 		"flint": {
 			"name": "destructuringConsistency",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"devDependenciesPresence": {
-		"eslint": [
-			{
-				"name": "package-json/require-devDependencies",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-devDependencies.md"
-			}
-		],
-		"flint": {
-			"name": "devDependenciesPresence",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "None"
-		}
-	},
-	"devDependenciesValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-devDependencies",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-devDependencies.md"
-			}
-		],
-		"flint": {
-			"name": "devDependenciesValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"directiveDisableSelectors": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-abusive-eslint-disable",
@@ -3643,10 +5710,7 @@
 		],
 		"flint": {
 			"name": "directiveDisableSelectors",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Core requires explicit disables",
@@ -3657,7 +5721,7 @@
 			}
 		]
 	},
-	"directiveDuplicateDisables": {
+	{
 		"eslint": [
 			{
 				"name": "@eslint-community/eslint-comments/no-duplicate-disable",
@@ -3666,15 +5730,12 @@
 		],
 		"flint": {
 			"name": "directiveDuplicateDisables",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Core detects duplicate disables"
 	},
-	"directiveMisleadingEnables": {
+	{
 		"eslint": [
 			{
 				"name": "@eslint-community/eslint-comments/no-aggregating-enable",
@@ -3683,15 +5744,12 @@
 		],
 		"flint": {
 			"name": "directiveMisleadingEnables",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Core requires explicit enables"
 	},
-	"directivePairs": {
+	{
 		"eslint": [
 			{
 				"name": "@eslint-community/eslint-comments/disable-enable-pair",
@@ -3700,15 +5758,12 @@
 		],
 		"flint": {
 			"name": "directivePairs",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		}
 	},
-	"directiveRequireDescriptions": {
+	{
 		"eslint": [
 			{
 				"name": "@eslint-community/eslint-comments/require-description",
@@ -3717,15 +5772,12 @@
 		],
 		"flint": {
 			"name": "directiveRequireDescriptions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"directiveRestrictedDisables": {
+	{
 		"eslint": [
 			{
 				"name": "@eslint-community/eslint-comments/no-restricted-disable",
@@ -3734,14 +5786,11 @@
 		],
 		"flint": {
 			"name": "directiveRestrictedDisables",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"directiveSelectors": {
+	{
 		"deno": [
 			{
 				"name": "ban-untagged-ignore",
@@ -3750,15 +5799,12 @@
 		],
 		"flint": {
 			"name": "directiveSelectors",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Handled by Flint core"
 	},
-	"directiveUnknownRules": {
+	{
 		"deno": [
 			{
 				"name": "ban-unknown-rule-code",
@@ -3767,15 +5813,12 @@
 		],
 		"flint": {
 			"name": "directiveUnknownRules",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Handled by Flint core"
 	},
-	"directiveUnlimitedDisables": {
+	{
 		"eslint": [
 			{
 				"name": "@eslint-community/eslint-comments/no-unlimited-disable",
@@ -3784,15 +5827,12 @@
 		],
 		"flint": {
 			"name": "directiveUnlimitedDisables",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Core requires explicit disables"
 	},
-	"directiveUnused": {
+	{
 		"deno": [
 			{
 				"name": "ban-unused-ignore",
@@ -3801,15 +5841,12 @@
 		],
 		"flint": {
 			"name": "directiveUnused",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Handled by Flint core"
 	},
-	"directiveUnusedDisables": {
+	{
 		"eslint": [
 			{
 				"name": "@eslint-community/eslint-comments/no-unused-disable",
@@ -3818,15 +5855,12 @@
 		],
 		"flint": {
 			"name": "directiveUnusedDisables",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Core detects unused disables"
 	},
-	"directiveUnusedEnables": {
+	{
 		"eslint": [
 			{
 				"name": "@eslint-community/eslint-comments/no-unused-enable",
@@ -3835,82 +5869,12 @@
 		],
 		"flint": {
 			"name": "directiveUnusedEnables",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Core detects unused enables"
 	},
-	"directoriesValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-directories",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-directories.md"
-			}
-		],
-		"flint": {
-			"name": "directoriesValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"distractingElements": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/no-distracting-elements",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-distracting-elements.md"
-			}
-		],
-		"flint": {
-			"name": "distractingElements",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/no-distracting-elements",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/no-distracting-elements.html"
-			}
-		]
-	},
-	"documentCookies": {
-		"biome": [
-			{
-				"name": "noDocumentCookie",
-				"url": "https://biomejs.dev/linter/rules/noDocumentCookie"
-			}
-		],
-		"eslint": [
-			{
-				"name": "unicorn/no-document-cookie",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-document-cookie.md"
-			}
-		],
-		"flint": {
-			"name": "documentCookies",
-			"plugin": {
-				"code": "browser",
-				"name": "Browser"
-			},
-			"preset": "Logical",
-			"strictness": "Strict"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/no-document-cookie",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-document-cookie.html"
-			}
-		]
-	},
-	"duplicateArguments": {
+	{
 		"biome": [
 			{
 				"name": "noDuplicateParameters",
@@ -3931,46 +5895,11 @@
 		],
 		"flint": {
 			"name": "duplicateArguments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		}
 	},
-	"duplicateProps": {
-		"deno": [
-			{
-				"name": "jsx-no-duplicate-props",
-				"url": "https://docs.deno.com/lint/rules/jsx-no-duplicate-props"
-			}
-		],
-		"flint": {
-			"name": "duplicateProps",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		}
-	},
-	"duplicateSpreads": {
-		"deno": [
-			{
-				"name": "jsx-props-no-spread-multi",
-				"url": "https://docs.deno.com/lint/rules/jsx-props-no-spread-multi"
-			}
-		],
-		"flint": {
-			"name": "duplicateSpreads",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		}
-	},
-	"dynamicDeletes": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-dynamic-delete",
@@ -3979,10 +5908,7 @@
 		],
 		"flint": {
 			"name": "dynamicDeletes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -3992,7 +5918,7 @@
 			}
 		]
 	},
-	"elseIfDuplicates": {
+	{
 		"biome": [
 			{
 				"name": "noDuplicateElseIf",
@@ -4007,10 +5933,7 @@
 		],
 		"flint": {
 			"name": "elseIfDuplicates",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -4020,7 +5943,7 @@
 			}
 		]
 	},
-	"elseReturns": {
+	{
 		"biome": [
 			{
 				"name": "noUselessElse",
@@ -4035,10 +5958,7 @@
 		],
 		"flint": {
 			"name": "elseReturns",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -4049,23 +5969,7 @@
 			}
 		]
 	},
-	"emphasisMarkerSpacing": {
-		"eslint": [
-			{
-				"name": "markdown/no-space-in-emphasis",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-space-in-emphasis.md"
-			}
-		],
-		"flint": {
-			"name": "emphasisMarkerSpacing",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"emptyBlocks": {
+	{
 		"biome": [
 			{
 				"name": "noEmptyBlockStatements",
@@ -4073,10 +5977,7 @@
 			}
 		],
 		"deno": [
-			{
-				"name": "no-empty",
-				"url": "https://docs.deno.com/lint/rules/no-empty"
-			}
+			{ "name": "no-empty", "url": "https://docs.deno.com/lint/rules/no-empty" }
 		],
 		"eslint": [
 			{
@@ -4086,10 +5987,7 @@
 		],
 		"flint": {
 			"name": "emptyBlocks",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -4099,7 +5997,7 @@
 			}
 		]
 	},
-	"emptyDestructures": {
+	{
 		"biome": [
 			{
 				"name": "noEmptyPattern",
@@ -4120,10 +6018,7 @@
 		],
 		"flint": {
 			"name": "emptyDestructures",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -4133,23 +6028,7 @@
 			}
 		]
 	},
-	"emptyDocuments": {
-		"eslint": [
-			{
-				"name": "yml/no-empty-document",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-document.html"
-			}
-		],
-		"flint": {
-			"name": "emptyDocuments",
-			"plugin": {
-				"code": "yml",
-				"name": "YML"
-			},
-			"preset": "Logical"
-		}
-	},
-	"emptyEnums": {
+	{
 		"deno": [
 			{
 				"name": "no-empty-enum",
@@ -4158,14 +6037,11 @@
 		],
 		"flint": {
 			"name": "emptyEnums",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"emptyExports": {
+	{
 		"biome": [
 			{
 				"name": "noUselessEmptyExport",
@@ -4180,10 +6056,7 @@
 		],
 		"flint": {
 			"name": "emptyExports",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -4193,23 +6066,7 @@
 			}
 		]
 	},
-	"emptyFields": {
-		"eslint": [
-			{
-				"name": "package-json/no-empty-fields",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/no-empty-fields.md"
-			}
-		],
-		"flint": {
-			"name": "emptyFields",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"emptyFiles": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-empty-file",
@@ -4218,10 +6075,7 @@
 		],
 		"flint": {
 			"name": "emptyFiles",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -4232,7 +6086,7 @@
 			}
 		]
 	},
-	"emptyFunctions": {
+	{
 		"biome": [
 			{
 				"name": "noEmptyBlockStatements",
@@ -4251,10 +6105,7 @@
 		],
 		"flint": {
 			"name": "emptyFunctions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -4265,40 +6116,7 @@
 			}
 		]
 	},
-	"emptyMappingKeys": {
-		"eslint": [
-			{
-				"name": "yml/no-empty-key",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-key.html"
-			}
-		],
-		"flint": {
-			"implemented": true,
-			"name": "emptyMappingKeys",
-			"plugin": {
-				"code": "yml",
-				"name": "YML"
-			},
-			"preset": "Logical"
-		}
-	},
-	"emptyMappingValues": {
-		"eslint": [
-			{
-				"name": "yml/no-empty-mapping-value",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-mapping-value.html"
-			}
-		],
-		"flint": {
-			"name": "emptyMappingValues",
-			"plugin": {
-				"code": "yml",
-				"name": "YML"
-			},
-			"preset": "Logical"
-		}
-	},
-	"emptyModuleAttributes": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/require-module-attributes",
@@ -4307,14 +6125,11 @@
 		],
 		"flint": {
 			"name": "emptyModuleAttributes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"emptyObjectTypes": {
+	{
 		"biome": [
 			{
 				"name": "noBannedTypes",
@@ -4339,10 +6154,7 @@
 		],
 		"flint": {
 			"name": "emptyObjectTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -4360,23 +6172,7 @@
 			}
 		]
 	},
-	"emptySequenceEntries": {
-		"eslint": [
-			{
-				"name": "yml/no-empty-sequence-entry",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-sequence-entry.html"
-			}
-		],
-		"flint": {
-			"name": "emptySequenceEntries",
-			"plugin": {
-				"code": "yml",
-				"name": "YML"
-			},
-			"preset": "Logical"
-		}
-	},
-	"emptyStaticBlocks": {
+	{
 		"biome": [
 			{
 				"name": "noEmptyBlockStatements",
@@ -4391,10 +6187,7 @@
 		],
 		"flint": {
 			"name": "emptyStaticBlocks",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -4404,7 +6197,7 @@
 			}
 		]
 	},
-	"emptyTypeParameterLists": {
+	{
 		"biome": [
 			{
 				"name": "noEmptyTypeParameters",
@@ -4413,14 +6206,11 @@
 		],
 		"flint": {
 			"name": "emptyTypeParameterLists",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"endingTernaryIfElses": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-ternary",
@@ -4429,30 +6219,11 @@
 		],
 		"flint": {
 			"name": "endingTernaryIfElses",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"enginesPresence": {
-		"eslint": [
-			{
-				"name": "package-json/require-engines",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-engines.md"
-			}
-		],
-		"flint": {
-			"name": "enginesPresence",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "None"
-		}
-	},
-	"enumInitializers": {
+	{
 		"biome": [
 			{
 				"name": "useEnumInitializers",
@@ -4467,10 +6238,7 @@
 		],
 		"flint": {
 			"name": "enumInitializers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -4480,7 +6248,7 @@
 			}
 		]
 	},
-	"enumMemberLiterals": {
+	{
 		"biome": [
 			{
 				"name": "useLiteralEnumMembers",
@@ -4495,10 +6263,7 @@
 		],
 		"flint": {
 			"name": "enumMemberLiterals",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -4508,7 +6273,7 @@
 			}
 		]
 	},
-	"enumMixedValues": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-misused-spread",
@@ -4517,10 +6282,7 @@
 		],
 		"flint": {
 			"name": "enumMixedValues",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -4530,12 +6292,9 @@
 			}
 		]
 	},
-	"enums": {
+	{
 		"biome": [
-			{
-				"name": "noEnum",
-				"url": "https://biomejs.dev/linter/rules/noEnum"
-			}
+			{ "name": "noEnum", "url": "https://biomejs.dev/linter/rules/noEnum" }
 		],
 		"eslint": [
 			{
@@ -4545,14 +6304,11 @@
 		],
 		"flint": {
 			"name": "enums",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"enumValueConsistency": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-mixed-enums",
@@ -4561,10 +6317,7 @@
 		],
 		"flint": {
 			"name": "enumValueConsistency",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -4574,7 +6327,7 @@
 			}
 		]
 	},
-	"enumValueDuplicates": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-duplicate-enum-values",
@@ -4583,10 +6336,7 @@
 		],
 		"flint": {
 			"name": "enumValueDuplicates",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -4596,7 +6346,7 @@
 			}
 		]
 	},
-	"equalityOperatorNegations": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-negation-in-equality-check",
@@ -4605,10 +6355,7 @@
 		],
 		"flint": {
 			"name": "equalityOperatorNegations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -4618,7 +6365,7 @@
 			}
 		]
 	},
-	"equalityOperators": {
+	{
 		"biome": [
 			{
 				"name": "noDoubleEquals",
@@ -4626,23 +6373,14 @@
 			}
 		],
 		"deno": [
-			{
-				"name": "eqeqeq",
-				"url": "https://docs.deno.com/lint/rules/eqeqeq"
-			}
+			{ "name": "eqeqeq", "url": "https://docs.deno.com/lint/rules/eqeqeq" }
 		],
 		"eslint": [
-			{
-				"name": "eqeqeq",
-				"url": "https://eslint.org/docs/latest/rules/eqeqeq"
-			}
+			{ "name": "eqeqeq", "url": "https://eslint.org/docs/latest/rules/eqeqeq" }
 		],
 		"flint": {
 			"name": "equalityOperators",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"notes": "Default ESLint's \"smart\" to true",
@@ -4653,7 +6391,7 @@
 			}
 		]
 	},
-	"errorMessages": {
+	{
 		"biome": [
 			{
 				"name": "useErrorMessage",
@@ -4668,10 +6406,7 @@
 		],
 		"flint": {
 			"name": "errorMessages",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		},
@@ -4682,7 +6417,7 @@
 			}
 		]
 	},
-	"errorSubclassProperties": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/custom-error-definition",
@@ -4691,15 +6426,12 @@
 		],
 		"flint": {
 			"name": "errorSubclassProperties",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		}
 	},
-	"errorUnnecessaryCaptureStackTraces": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-useless-error-capture-stack-trace",
@@ -4708,14 +6440,11 @@
 		],
 		"flint": {
 			"name": "errorUnnecessaryCaptureStackTraces",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"escapeSequenceCasing": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/escape-case",
@@ -4724,10 +6453,7 @@
 		],
 		"flint": {
 			"name": "escapeSequenceCasing",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -4738,7 +6464,7 @@
 			}
 		]
 	},
-	"evals": {
+	{
 		"biome": [
 			{
 				"name": "noGlobalEval",
@@ -4746,10 +6472,7 @@
 			}
 		],
 		"deno": [
-			{
-				"name": "no-eval",
-				"url": "https://docs.deno.com/lint/rules/no-eval"
-			}
+			{ "name": "no-eval", "url": "https://docs.deno.com/lint/rules/no-eval" }
 		],
 		"eslint": [
 			{
@@ -4759,10 +6482,7 @@
 		],
 		"flint": {
 			"name": "evals",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -4772,53 +6492,7 @@
 			}
 		]
 	},
-	"eventClasses": {
-		"eslint": [
-			{
-				"name": "unicorn/prefer-event-target",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-event-target.md"
-			}
-		],
-		"flint": {
-			"name": "eventClasses",
-			"plugin": {
-				"code": "browser",
-				"name": "Browser"
-			},
-			"preset": "Logical",
-			"strictness": "Strict"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/prefer-event-target",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-event-target.html"
-			}
-		]
-	},
-	"eventListenerSubscriptions": {
-		"eslint": [
-			{
-				"name": "unicorn/prefer-add-event-listener",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-add-event-listener.md"
-			}
-		],
-		"flint": {
-			"name": "eventListenerSubscriptions",
-			"plugin": {
-				"code": "browser",
-				"name": "Browser"
-			},
-			"preset": "Logical",
-			"strictness": "Strict"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/prefer-add-event-listener",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-add-event-listener.html"
-			}
-		]
-	},
-	"evolvingVariableTypes": {
+	{
 		"biome": [
 			{
 				"name": "noImplicitAnyLet",
@@ -4827,14 +6501,11 @@
 		],
 		"flint": {
 			"name": "evolvingVariableTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"exceptionAssignments": {
+	{
 		"biome": [
 			{
 				"name": "noCatchAssign",
@@ -4855,10 +6526,7 @@
 		],
 		"flint": {
 			"name": "exceptionAssignments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -4868,7 +6536,7 @@
 			}
 		]
 	},
-	"explicitAnys": {
+	{
 		"biome": [
 			{
 				"name": "noExplicitAny",
@@ -4889,10 +6557,7 @@
 		],
 		"flint": {
 			"name": "explicitAnys",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -4902,7 +6567,7 @@
 			}
 		]
 	},
-	"exponentiationOperators": {
+	{
 		"biome": [
 			{
 				"name": "useExponentiationOperator",
@@ -4917,10 +6582,7 @@
 		],
 		"flint": {
 			"name": "exponentiationOperators",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -4930,7 +6592,7 @@
 			}
 		]
 	},
-	"exportDefault": {
+	{
 		"eslint": [
 			{
 				"name": "import/prefer-default-export",
@@ -4939,10 +6601,7 @@
 		],
 		"flint": {
 			"name": "exportDefault",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -4952,7 +6611,7 @@
 			}
 		]
 	},
-	"exportFromImports": {
+	{
 		"biome": [
 			{
 				"name": "noExportedImports",
@@ -4967,14 +6626,11 @@
 		],
 		"flint": {
 			"name": "exportFromImports",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"exportGroups": {
+	{
 		"eslint": [
 			{
 				"name": "import/group-exports",
@@ -4983,10 +6639,7 @@
 		],
 		"flint": {
 			"name": "exportGroups",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -4996,7 +6649,7 @@
 			}
 		]
 	},
-	"exportLast": {
+	{
 		"eslint": [
 			{
 				"name": "import/exports-last",
@@ -5005,10 +6658,7 @@
 		],
 		"flint": {
 			"name": "exportLast",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -5018,7 +6668,7 @@
 			}
 		]
 	},
-	"exportMutables": {
+	{
 		"eslint": [
 			{
 				"name": "import/no-mutable-exports",
@@ -5027,10 +6677,7 @@
 		],
 		"flint": {
 			"name": "exportMutables",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -5040,78 +6687,7 @@
 			}
 		]
 	},
-	"exports": {
-		"eslint": [
-			{
-				"name": "perfectionist/sort-named-exports",
-				"url": "https://perfectionist.dev/rules/sort-named-exports"
-			}
-		],
-		"flint": {
-			"name": "exports",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"exportsAssignments": {
-		"eslint": [
-			{
-				"name": "n/no-exports-assign",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-exports-assign.md"
-			}
-		],
-		"flint": {
-			"name": "exportsAssignments",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "node/no-exports-assign",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/node/no-exports-assign.html"
-			}
-		]
-	},
-	"exportsStyle": {
-		"eslint": [
-			{
-				"name": "n/exports-style",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/exports-style.md"
-			}
-		],
-		"flint": {
-			"name": "exportsStyle",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "CJS-specific"
-	},
-	"exportsValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-exports",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-exports.md"
-			}
-		],
-		"flint": {
-			"name": "exportsValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"exportUniqueNames": {
+	{
 		"eslint": [
 			{
 				"name": "import/exports",
@@ -5120,10 +6696,7 @@
 		],
 		"flint": {
 			"name": "exportUniqueNames",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -5133,7 +6706,7 @@
 			}
 		]
 	},
-	"externalHttpImports": {
+	{
 		"deno": [
 			{
 				"name": "no-external-import",
@@ -5142,14 +6715,11 @@
 		],
 		"flint": {
 			"name": "externalHttpImports",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"extraneousClasses": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-extraneous-class",
@@ -5158,10 +6728,7 @@
 		],
 		"flint": {
 			"name": "extraneousClasses",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		},
@@ -5172,58 +6739,7 @@
 			}
 		]
 	},
-	"extraneousImports": {
-		"eslint": [
-			{
-				"name": "n/no-extraneous-import",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-extraneous-import.md"
-			}
-		],
-		"flint": {
-			"name": "extraneousImports",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Superseded by Knip"
-	},
-	"extraneousRequires": {
-		"eslint": [
-			{
-				"name": "n/no-extraneous-require",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-extraneous-require.md"
-			}
-		],
-		"flint": {
-			"name": "extraneousRequires",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Superseded by Knip"
-	},
-	"fencedCodeLanguages": {
-		"eslint": [
-			{
-				"name": "markdown/fenced-code-language",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/fenced-code-language.md"
-			}
-		],
-		"flint": {
-			"name": "fencedCodeLanguages",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Stylistic",
-			"strictness": "Strict"
-		}
-	},
-	"fetchMethodBodies": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-invalid-fetch-options",
@@ -5232,10 +6748,7 @@
 		],
 		"flint": {
 			"name": "fetchMethodBodies",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -5245,24 +6758,7 @@
 			}
 		]
 	},
-	"fileExtensions": {
-		"eslint": [
-			{
-				"name": "yml/file-extension",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/file-extension.html"
-			}
-		],
-		"flint": {
-			"name": "fileExtensions",
-			"plugin": {
-				"code": "yml",
-				"name": "YML"
-			},
-			"preset": "Stylistic",
-			"strictness": "Strict"
-		}
-	},
-	"filenameCasing": {
+	{
 		"biome": [
 			{
 				"name": "useFilenamingConvention",
@@ -5277,10 +6773,7 @@
 		],
 		"flint": {
 			"name": "filenameCasing",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -5290,106 +6783,7 @@
 			}
 		]
 	},
-	"filePathsFromImportMeta": {
-		"eslint": [
-			{
-				"name": "unicorn/prefer-import-meta-properties",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-import-meta-properties.md"
-			}
-		],
-		"flint": {
-			"name": "filePathsFromImportMeta",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Stylistic",
-			"strictness": "Strict"
-		}
-	},
-	"fileReadJSONBuffers": {
-		"eslint": [
-			{
-				"name": "unicorn/prefer-json-parse-buffer",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-json-parse-buffer.md"
-			}
-		],
-		"flint": {
-			"name": "fileReadJSONBuffers",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Stylistic",
-			"strictness": "Strict"
-		}
-	},
-	"filesPresence": {
-		"eslint": [
-			{
-				"name": "package-json/require-files",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-files.md"
-			}
-		],
-		"flint": {
-			"name": "filesPresence",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "None"
-		}
-	},
-	"filesRedundancy": {
-		"eslint": [
-			{
-				"name": "package-json/no-redundant-files",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/no-redundant-files.md"
-			}
-		],
-		"flint": {
-			"name": "filesRedundancy",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"filesValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-files",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-files.md"
-			}
-		],
-		"flint": {
-			"name": "filesValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"floatingDecimals": {
-		"eslint": [
-			{
-				"name": "jsonc/no-floating-decimal",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-floating-decimal.html"
-			}
-		],
-		"flint": {
-			"name": "floatingDecimals",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"floatingPromises": {
+	{
 		"biome": [
 			{
 				"name": "noFloatingPromises",
@@ -5404,10 +6798,7 @@
 		],
 		"flint": {
 			"name": "floatingPromises",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -5417,7 +6808,7 @@
 			}
 		]
 	},
-	"forDirections": {
+	{
 		"biome": [
 			{
 				"name": "useValidForDirection",
@@ -5438,10 +6829,7 @@
 		],
 		"flint": {
 			"name": "forDirections",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -5451,7 +6839,7 @@
 			}
 		]
 	},
-	"forInArrays": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-for-in-array",
@@ -5461,10 +6849,7 @@
 		"flint": {
 			"implemented": true,
 			"name": "forInArrays",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -5474,7 +6859,7 @@
 			}
 		]
 	},
-	"functionAssignments": {
+	{
 		"biome": [
 			{
 				"name": "noFunctionAssign",
@@ -5495,10 +6880,7 @@
 		],
 		"flint": {
 			"name": "functionAssignments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -5508,7 +6890,7 @@
 			}
 		]
 	},
-	"functionCallSpreads": {
+	{
 		"eslint": [
 			{
 				"name": "prefer-spread",
@@ -5521,10 +6903,7 @@
 		],
 		"flint": {
 			"name": "functionCallSpreads",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -5538,7 +6917,7 @@
 			}
 		]
 	},
-	"functionDeclarationStyles": {
+	{
 		"eslint": [
 			{
 				"name": "func-style",
@@ -5547,10 +6926,7 @@
 		],
 		"flint": {
 			"name": "functionDeclarationStyles",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -5560,7 +6936,7 @@
 			}
 		]
 	},
-	"functionDefinitionScopeConsistency": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/consistent-function-scoping",
@@ -5569,10 +6945,7 @@
 		],
 		"flint": {
 			"name": "functionDefinitionScopeConsistency",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -5583,7 +6956,7 @@
 			}
 		]
 	},
-	"functionNameMatches": {
+	{
 		"eslint": [
 			{
 				"name": "func-name-matching",
@@ -5592,14 +6965,11 @@
 		],
 		"flint": {
 			"name": "functionNameMatches",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"functionNames": {
+	{
 		"eslint": [
 			{
 				"name": "func-names",
@@ -5608,10 +6978,7 @@
 		],
 		"flint": {
 			"name": "functionNames",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -5621,7 +6988,7 @@
 			}
 		]
 	},
-	"functionNewCalls": {
+	{
 		"eslint": [
 			{
 				"name": "no-new-func",
@@ -5630,10 +6997,7 @@
 		],
 		"flint": {
 			"name": "functionNewCalls",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -5643,7 +7007,7 @@
 			}
 		]
 	},
-	"functionReturnTypes": {
+	{
 		"biome": [
 			{
 				"name": "useExplicitType",
@@ -5664,10 +7028,7 @@
 		],
 		"flint": {
 			"name": "functionReturnTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -5677,7 +7038,7 @@
 			}
 		]
 	},
-	"functionTypeDeclarations": {
+	{
 		"biome": [
 			{
 				"name": "useShorthandFunctionType",
@@ -5692,10 +7053,7 @@
 		],
 		"flint": {
 			"name": "functionTypeDeclarations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -5705,12 +7063,9 @@
 			}
 		]
 	},
-	"generatorFunctionYields": {
+	{
 		"biome": [
-			{
-				"name": "useYield",
-				"url": "https://biomejs.dev/linter/rules/useYield"
-			}
+			{ "name": "useYield", "url": "https://biomejs.dev/linter/rules/useYield" }
 		],
 		"deno": [
 			{
@@ -5726,10 +7081,7 @@
 		],
 		"flint": {
 			"name": "generatorFunctionYields",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -5739,7 +7091,7 @@
 			}
 		]
 	},
-	"genericConstructorCalls": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/consistent-generic-constructors",
@@ -5748,10 +7100,7 @@
 		],
 		"flint": {
 			"name": "genericConstructorCalls",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -5761,7 +7110,7 @@
 			}
 		]
 	},
-	"getterReturns": {
+	{
 		"biome": [
 			{
 				"name": "useGetterReturn",
@@ -5782,10 +7131,7 @@
 		],
 		"flint": {
 			"name": "getterReturns",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -5795,7 +7141,7 @@
 			}
 		]
 	},
-	"getterSetterPairedTypes": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/related-getter-setter-pairs",
@@ -5804,10 +7150,7 @@
 		],
 		"flint": {
 			"name": "getterSetterPairedTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -5817,7 +7160,7 @@
 			}
 		]
 	},
-	"globalAssignments": {
+	{
 		"biome": [
 			{
 				"name": "noGlobalAssign",
@@ -5838,10 +7181,7 @@
 		],
 		"flint": {
 			"name": "globalAssignments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -5851,39 +7191,7 @@
 			}
 		]
 	},
-	"globalBuffer": {
-		"eslint": [
-			{
-				"name": "n/prefer-global/buffer",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
-			}
-		],
-		"flint": {
-			"name": "globalBuffer",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"globalConsole": {
-		"eslint": [
-			{
-				"name": "n/prefer-global/console",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
-			}
-		],
-		"flint": {
-			"name": "globalConsole",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"globalObjectCalls": {
+	{
 		"biome": [
 			{
 				"name": "noGlobalObjectCalls",
@@ -5904,10 +7212,7 @@
 		],
 		"flint": {
 			"name": "globalObjectCalls",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -5917,67 +7222,7 @@
 			}
 		]
 	},
-	"globalProcess": {
-		"biome": [
-			{
-				"name": "noProcessGlobal",
-				"url": "https://biomejs.dev/linter/rules/noProcessGlobal"
-			}
-		],
-		"deno": [
-			{
-				"name": "no-process-global",
-				"url": "https://docs.deno.com/lint/rules/no-process-global"
-			}
-		],
-		"eslint": [
-			{
-				"name": "n/prefer-global/process",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
-			}
-		],
-		"flint": {
-			"name": "globalProcess",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"globalTextDecoder": {
-		"eslint": [
-			{
-				"name": "n/prefer-global/text-decoder",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
-			}
-		],
-		"flint": {
-			"name": "globalTextDecoder",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"globalTextEncoder": {
-		"eslint": [
-			{
-				"name": "n/prefer-global/text-encoder",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
-			}
-		],
-		"flint": {
-			"name": "globalTextEncoder",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"globalThisAliases": {
+	{
 		"deno": [
 			{
 				"name": "no-window",
@@ -5996,10 +7241,7 @@
 		],
 		"flint": {
 			"name": "globalThisAliases",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -6010,39 +7252,7 @@
 			}
 		]
 	},
-	"globalURL": {
-		"eslint": [
-			{
-				"name": "n/prefer-global/url-search-params",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
-			}
-		],
-		"flint": {
-			"name": "globalURL",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"globalURLSearchParams": {
-		"eslint": [
-			{
-				"name": "n/prefer-global/url-search-params",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
-			}
-		],
-		"flint": {
-			"name": "globalURLSearchParams",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"groupedAccessorPairs": {
+	{
 		"biome": [
 			{
 				"name": "useGroupedAccessorPairs",
@@ -6057,10 +7267,7 @@
 		],
 		"flint": {
 			"name": "groupedAccessorPairs",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -6070,7 +7277,7 @@
 			}
 		]
 	},
-	"guardedForIns": {
+	{
 		"biome": [
 			{
 				"name": "useGuardForIn",
@@ -6091,10 +7298,7 @@
 		],
 		"flint": {
 			"name": "guardedForIns",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -6104,141 +7308,7 @@
 			}
 		]
 	},
-	"hashbangs": {
-		"eslint": [
-			{
-				"name": "n/hashbang",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/hashbang.md"
-			}
-		],
-		"flint": {
-			"name": "hashbangs",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Logical"
-		}
-	},
-	"headingContents": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/heading-has-content",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/heading-has-content.md"
-			}
-		],
-		"flint": {
-			"name": "headingContents",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		}
-	},
-	"headingDuplicates": {
-		"eslint": [
-			{
-				"name": "markdown/no-duplicate-headings",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-duplicate-headings.md"
-			}
-		],
-		"flint": {
-			"name": "headingDuplicates",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Stylistic",
-			"strictness": "Strict"
-		},
-		"notes": "Enable with Markdownlint's siblings_only equivalent"
-	},
-	"headingIncrements": {
-		"eslint": [
-			{
-				"name": "markdown/heading-increment",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/heading-increment.md"
-			}
-		],
-		"flint": {
-			"implemented": true,
-			"name": "headingIncrements",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Logical"
-		}
-	},
-	"headingSpaces": {
-		"eslint": [
-			{
-				"name": "markdown/no-missing-atx-heading-space",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-missing-atx-heading-space.md"
-			}
-		],
-		"flint": {
-			"name": "headingSpaces",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "I intend to write a Prettier plugin."
-	},
-	"headingsRootDuplicates": {
-		"eslint": [
-			{
-				"name": "markdown/no-multiple-h1",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-multiple-h1.md"
-			}
-		],
-		"flint": {
-			"name": "headingsRootDuplicates",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Logical",
-			"strictness": "Strict"
-		}
-	},
-	"heritageClauses": {
-		"eslint": [
-			{
-				"name": "perfectionist/sort-heritage-clauses",
-				"url": "https://perfectionist.dev/rules/sort-heritage-clauses"
-			}
-		],
-		"flint": {
-			"name": "heritageClauses",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"hexadecimalNumericLiterals": {
-		"eslint": [
-			{
-				"name": "jsonc/no-hexadecimal-numeric-literals",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-hexadecimal-numeric-literals.html"
-			}
-		],
-		"flint": {
-			"name": "hexadecimalNumericLiterals",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"hexEscapes": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-hex-escape",
@@ -6247,10 +7317,7 @@
 		],
 		"flint": {
 			"name": "hexEscapes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -6260,78 +7327,7 @@
 			}
 		]
 	},
-	"homepageValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-homepage",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-homepage.md"
-			}
-		],
-		"flint": {
-			"name": "homepageValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"html": {
-		"eslint": [
-			{
-				"name": "markdown/no-html",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-html.md"
-			}
-		],
-		"flint": {
-			"name": "html",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"htmlLangs": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/html-has-lang",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/html-has-lang.md"
-			}
-		],
-		"flint": {
-			"name": "htmlLangs",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/html-has-lang",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/html-has-lang.html"
-			}
-		]
-	},
-	"identifierEscapeSequences": {
-		"eslint": [
-			{
-				"name": "jsonc/no-escape-sequence-in-identifier",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-escape-sequence-in-identifier.html"
-			}
-		],
-		"flint": {
-			"name": "identifierEscapeSequences",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"identifierMatches": {
+	{
 		"eslint": [
 			{
 				"name": "id-match",
@@ -6340,53 +7336,11 @@
 		],
 		"flint": {
 			"name": "identifierMatches",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"identifierNumbers": {
-		"eslint": [
-			{
-				"name": "jsonc/no-number-props",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-number-props.html"
-			}
-		],
-		"flint": {
-			"name": "identifierNumbers",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"iframeTitles": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/iframe-has-title",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/iframe-has-title.md"
-			}
-		],
-		"flint": {
-			"name": "iframeTitles",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/iframe-has-title",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/iframe-has-title.html"
-			}
-		]
-	},
-	"iifeReadability": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-unreadable-iife",
@@ -6395,10 +7349,7 @@
 		],
 		"flint": {
 			"name": "iifeReadability",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -6408,61 +7359,7 @@
 			}
 		]
 	},
-	"imageAltRedundancy": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/img-redundant-alt",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/img-redundant-alt.md"
-			}
-		],
-		"flint": {
-			"name": "imageAltRedundancy",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/img-redundant-alt",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/img-redundant-alt.html"
-			}
-		]
-	},
-	"imageAltTexts": {
-		"eslint": [
-			{
-				"name": "markdown/require-alt-text",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/require-alt-text.md"
-			}
-		],
-		"flint": {
-			"name": "imageAltTexts",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Logical"
-		}
-	},
-	"imageContents": {
-		"eslint": [
-			{
-				"name": "markdown/no-empty-images",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-empty-images.md"
-			}
-		],
-		"flint": {
-			"name": "imageContents",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Logical"
-		}
-	},
-	"implicitCoercions": {
+	{
 		"biome": [
 			{
 				"name": "noImplicitCoercions",
@@ -6477,30 +7374,11 @@
 		],
 		"flint": {
 			"name": "implicitCoercions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"implicitGlobals": {
-		"eslint": [
-			{
-				"name": "no-implicit-globals",
-				"url": "https://eslint.org/docs/latest/rules/no-implicit-globals"
-			}
-		],
-		"flint": {
-			"name": "implicitGlobals",
-			"plugin": {
-				"code": "browser",
-				"name": "Browser"
-			},
-			"preset": "Logical"
-		}
-	},
-	"impliedEvals": {
+	{
 		"eslint": [
 			{
 				"name": "no-implied-eval",
@@ -6513,10 +7391,7 @@
 		],
 		"flint": {
 			"name": "impliedEvals",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -6526,7 +7401,7 @@
 			}
 		]
 	},
-	"importAbsolutePaths": {
+	{
 		"eslint": [
 			{
 				"name": "import/no-absolute-path",
@@ -6535,10 +7410,7 @@
 		],
 		"flint": {
 			"name": "importAbsolutePaths",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -6548,7 +7420,7 @@
 			}
 		]
 	},
-	"importAssertions": {
+	{
 		"deno": [
 			{
 				"name": "no-import-assertions",
@@ -6557,15 +7429,12 @@
 		],
 		"flint": {
 			"name": "importAssertions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Generally handled by parsers."
 	},
-	"importAssignments": {
+	{
 		"biome": [
 			{
 				"name": "noImportAssign",
@@ -6586,14 +7455,11 @@
 		],
 		"flint": {
 			"name": "importAssignments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		}
 	},
-	"importCycles": {
+	{
 		"biome": [
 			{
 				"name": "noImportCycles",
@@ -6608,10 +7474,7 @@
 		],
 		"flint": {
 			"name": "importCycles",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -6621,7 +7484,7 @@
 			}
 		]
 	},
-	"importDefaults": {
+	{
 		"eslint": [
 			{
 				"name": "import/default",
@@ -6630,10 +7493,7 @@
 		],
 		"flint": {
 			"name": "importDefaults",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Handled by TypeScript",
@@ -6644,7 +7504,7 @@
 			}
 		]
 	},
-	"importDuplicates": {
+	{
 		"eslint": [
 			{
 				"name": "import/no-duplicates",
@@ -6653,10 +7513,7 @@
 		],
 		"flint": {
 			"name": "importDuplicates",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -6666,23 +7523,7 @@
 			}
 		]
 	},
-	"importedNamespaceDynamicAccesses": {
-		"biome": [
-			{
-				"name": "noDynamicNamespaceImportAccess",
-				"url": "https://biomejs.dev/linter/rules/noDynamicNamespaceImportAccess"
-			}
-		],
-		"flint": {
-			"name": "importedNamespaceDynamicAccesses",
-			"plugin": {
-				"code": "performance",
-				"name": "Performance"
-			},
-			"preset": "Logical"
-		}
-	},
-	"importEmptyBlocks": {
+	{
 		"eslint": [
 			{
 				"name": "import/no-empty-named-blocks",
@@ -6691,10 +7532,7 @@
 		],
 		"flint": {
 			"name": "importEmptyBlocks",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -6704,7 +7542,7 @@
 			}
 		]
 	},
-	"importExtraneousDependencies": {
+	{
 		"eslint": [
 			{
 				"name": "import/no-extraneous-dependencies",
@@ -6713,49 +7551,12 @@
 		],
 		"flint": {
 			"name": "importExtraneousDependencies",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		}
 	},
-	"importFileExtensions": {
-		"biome": [
-			{
-				"name": "useImportExtensions",
-				"url": "https://biomejs.dev/linter/rules/useImportExtensions"
-			}
-		],
-		"deno": [
-			{
-				"name": "no-sloppy-imports",
-				"url": "https://docs.deno.com/lint/rules/no-sloppy-imports"
-			}
-		],
-		"eslint": [
-			{
-				"name": "n/file-extension-in-import",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/file-extension-in-import.md"
-			}
-		],
-		"flint": {
-			"name": "importFileExtensions",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "None"
-		},
-		"oxlint": [
-			{
-				"name": "import/extensions",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/extensions.html"
-			}
-		]
-	},
-	"importFirst": {
+	{
 		"eslint": [
 			{
 				"name": "import/first",
@@ -6764,10 +7565,7 @@
 		],
 		"flint": {
 			"name": "importFirst",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -6777,7 +7575,7 @@
 			}
 		]
 	},
-	"importMaximumDependencies": {
+	{
 		"eslint": [
 			{
 				"name": "import/max-dependencies",
@@ -6786,10 +7584,7 @@
 		],
 		"flint": {
 			"name": "importMaximumDependencies",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -6799,7 +7594,7 @@
 			}
 		]
 	},
-	"importNameMatches": {
+	{
 		"eslint": [
 			{
 				"name": "import/named",
@@ -6808,10 +7603,7 @@
 		],
 		"flint": {
 			"name": "importNameMatches",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -6821,7 +7613,7 @@
 			}
 		]
 	},
-	"importNamespaceProperties": {
+	{
 		"eslint": [
 			{
 				"name": "import/namespace",
@@ -6830,10 +7622,7 @@
 		],
 		"flint": {
 			"name": "importNamespaceProperties",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Handled by TypeScript",
@@ -6844,7 +7633,7 @@
 			}
 		]
 	},
-	"importNamespaces": {
+	{
 		"eslint": [
 			{
 				"name": "import/no-namespace",
@@ -6853,10 +7642,7 @@
 		],
 		"flint": {
 			"name": "importNamespaces",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -6866,7 +7652,7 @@
 			}
 		]
 	},
-	"importSelf": {
+	{
 		"eslint": [
 			{
 				"name": "import/no-self-import",
@@ -6875,10 +7661,7 @@
 		],
 		"flint": {
 			"name": "importSelf",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -6888,7 +7671,7 @@
 			}
 		]
 	},
-	"importsSorting": {
+	{
 		"eslint": [
 			{
 				"name": "sort-imports",
@@ -6897,14 +7680,11 @@
 		],
 		"flint": {
 			"name": "importsSorting",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"importTypeSideEffects": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-import-type-side-effects",
@@ -6913,10 +7693,7 @@
 		],
 		"flint": {
 			"name": "importTypeSideEffects",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "None"
 		},
 		"oxlint": [
@@ -6926,7 +7703,7 @@
 			}
 		]
 	},
-	"importUnnecessaryPathSegments": {
+	{
 		"eslint": [
 			{
 				"name": "import/no-useless-path-segments",
@@ -6935,10 +7712,7 @@
 		],
 		"flint": {
 			"name": "importUnnecessaryPathSegments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -6948,7 +7722,7 @@
 			}
 		]
 	},
-	"indexedObjectTypes": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/consistent-indexed-object-style",
@@ -6957,10 +7731,7 @@
 		],
 		"flint": {
 			"name": "indexedObjectTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -6970,24 +7741,7 @@
 			}
 		]
 	},
-	"infinity": {
-		"eslint": [
-			{
-				"name": "jsonc/no-infinity",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-infinity.html"
-			}
-		],
-		"flint": {
-			"name": "infinity",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"inlineComments": {
+	{
 		"eslint": [
 			{
 				"name": "no-inline-comments",
@@ -6996,14 +7750,11 @@
 		],
 		"flint": {
 			"name": "inlineComments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"innerDeclarations": {
+	{
 		"biome": [
 			{
 				"name": "noInnerDeclarations",
@@ -7024,10 +7775,7 @@
 		],
 		"flint": {
 			"name": "innerDeclarations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -7037,7 +7785,7 @@
 			}
 		]
 	},
-	"instanceOfArrays": {
+	{
 		"biome": [
 			{
 				"name": "useIsArray",
@@ -7052,10 +7800,7 @@
 		],
 		"flint": {
 			"name": "instanceOfArrays",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"notes": "Only for built-ins with a static .is* (Array)",
@@ -7070,71 +7815,7 @@
 			}
 		]
 	},
-	"interactiveElementNonInteractiveRoles": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/no-interactive-element-to-noninteractive-role",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-interactive-element-to-noninteractive-role.md"
-			}
-		],
-		"flint": {
-			"name": "interactiveElementNonInteractiveRoles",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		}
-	},
-	"interactiveElementsFocusable": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/interactive-elements-focusable",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/interactive-elements-focusable.md"
-			}
-		],
-		"flint": {
-			"name": "interactiveElementsFocusable",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		}
-	},
-	"interfaces": {
-		"eslint": [
-			{
-				"name": "perfectionist/sort-interfaces",
-				"url": "https://perfectionist.dev/rules/sort-interfaces"
-			}
-		],
-		"flint": {
-			"name": "interfaces",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"intersectionTypes": {
-		"eslint": [
-			{
-				"name": "perfectionist/sort-intersection-types",
-				"url": "https://perfectionist.dev/rules/sort-intersection-types"
-			}
-		],
-		"flint": {
-			"name": "intersectionTypes",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"invalidThis": {
+	{
 		"eslint": [
 			{
 				"name": "no-invalid-this",
@@ -7147,14 +7828,11 @@
 		],
 		"flint": {
 			"name": "invalidThis",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		}
 	},
-	"invalidVoidTypes": {
+	{
 		"biome": [
 			{
 				"name": "noConfusingVoidType",
@@ -7169,36 +7847,14 @@
 		],
 		"flint": {
 			"name": "invalidVoidTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		}
 	},
-	"irregularWhitespace": {
-		"eslint": [
-			{
-				"name": "yml/no-irregular-whitespace",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-irregular-whitespace.html"
-			}
-		],
-		"flint": {
-			"name": "irregularWhitespace",
-			"plugin": {
-				"code": "yml",
-				"name": "YML"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"isNaNComparisons": {
+	{
 		"biome": [
-			{
-				"name": "useIsNan",
-				"url": "https://biomejs.dev/linter/rules/useIsNan"
-			}
+			{ "name": "useIsNan", "url": "https://biomejs.dev/linter/rules/useIsNan" }
 		],
 		"deno": [
 			{
@@ -7214,10 +7870,7 @@
 		],
 		"flint": {
 			"name": "isNaNComparisons",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -7227,23 +7880,7 @@
 			}
 		]
 	},
-	"iterableKeys": {
-		"deno": [
-			{
-				"name": "jsx-key",
-				"url": "https://docs.deno.com/lint/rules/jsx-key"
-			}
-		],
-		"flint": {
-			"name": "iterableKeys",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"iteratorMethodFunctionReferences": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-array-callback-reference",
@@ -7252,14 +7889,11 @@
 		],
 		"flint": {
 			"name": "iteratorMethodFunctionReferences",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsdocAccessTags": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/check-access",
@@ -7268,10 +7902,7 @@
 		],
 		"flint": {
 			"name": "jsdocAccessTags",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -7281,7 +7912,7 @@
 			}
 		]
 	},
-	"jsdocAlignment": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/check-alignment",
@@ -7290,15 +7921,12 @@
 		],
 		"flint": {
 			"name": "jsdocAlignment",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "I intend to write a Prettier plugin."
 	},
-	"jsdocAsterisks": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/no-multi-asterisks",
@@ -7311,15 +7939,12 @@
 		],
 		"flint": {
 			"name": "jsdocAsterisks",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"jsdocBlankBlockDescriptions": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/no-blank-block-descriptions",
@@ -7328,14 +7953,11 @@
 		],
 		"flint": {
 			"name": "jsdocBlankBlockDescriptions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsdocConvertToJSDocComments": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/convert-to-jsdoc-comments",
@@ -7344,14 +7966,11 @@
 		],
 		"flint": {
 			"name": "jsdocConvertToJSDocComments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsdocDefaults": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/no-defaults",
@@ -7360,10 +7979,7 @@
 		],
 		"flint": {
 			"name": "jsdocDefaults",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -7373,7 +7989,7 @@
 			}
 		]
 	},
-	"jsdocDefinedTypes": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/no-undefined-types",
@@ -7382,14 +7998,11 @@
 		],
 		"flint": {
 			"name": "jsdocDefinedTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsdocDescriptionCompleteSentences": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-description-complete-sentence",
@@ -7398,14 +8011,11 @@
 		],
 		"flint": {
 			"name": "jsdocDescriptionCompleteSentences",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsdocDescriptions": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-description",
@@ -7414,14 +8024,11 @@
 		],
 		"flint": {
 			"name": "jsdocDescriptions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsdocEmptyBlocks": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/no-blank-blocks",
@@ -7430,14 +8037,11 @@
 		],
 		"flint": {
 			"name": "jsdocEmptyBlocks",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"jsdocEmptyTags": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/empty-tags",
@@ -7446,10 +8050,7 @@
 		],
 		"flint": {
 			"name": "jsdocEmptyTags",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -7459,7 +8060,7 @@
 			}
 		]
 	},
-	"jsdocExamples": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-example",
@@ -7468,14 +8069,11 @@
 		],
 		"flint": {
 			"name": "jsdocExamples",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsdocFileOverviews": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-file-overview",
@@ -7484,14 +8082,11 @@
 		],
 		"flint": {
 			"name": "jsdocFileOverviews",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsdocImplementsTags": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/implements-on-classes",
@@ -7500,10 +8095,7 @@
 		],
 		"flint": {
 			"name": "jsdocImplementsTags",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -7513,7 +8105,7 @@
 			}
 		]
 	},
-	"jsdocImportsAsDependencies": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/imports-as-dependencies",
@@ -7522,14 +8114,11 @@
 		],
 		"flint": {
 			"name": "jsdocImportsAsDependencies",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsdocIndentation": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/check-indentation",
@@ -7538,15 +8127,12 @@
 		],
 		"flint": {
 			"name": "jsdocIndentation",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "I intend to write a Prettier plugin."
 	},
-	"jsdocInformativeDocs": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/informative-docs",
@@ -7555,15 +8141,12 @@
 		],
 		"flint": {
 			"name": "jsdocInformativeDocs",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"jsdocLineAlignment": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/check-line-alignment",
@@ -7572,15 +8155,12 @@
 		],
 		"flint": {
 			"name": "jsdocLineAlignment",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "I intend to write a Prettier plugin."
 	},
-	"jsdocMatchDescriptions": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/match-description",
@@ -7589,14 +8169,11 @@
 		],
 		"flint": {
 			"name": "jsdocMatchDescriptions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsdocMatchNames": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/match-names",
@@ -7605,14 +8182,11 @@
 		],
 		"flint": {
 			"name": "jsdocMatchNames",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsdocMisleadingBlocks": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/no-bad-blocks",
@@ -7621,15 +8195,12 @@
 		],
 		"flint": {
 			"name": "jsdocMisleadingBlocks",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"jsdocMissingSyntax": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/no-missing-syntax",
@@ -7638,14 +8209,11 @@
 		],
 		"flint": {
 			"name": "jsdocMissingSyntax",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsdocMultilineBlocks": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/multiline-blocks",
@@ -7654,15 +8222,12 @@
 		],
 		"flint": {
 			"name": "jsdocMultilineBlocks",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"jsdocParameterDescriptionHyphens": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-hyphen-before-param-description",
@@ -7671,15 +8236,12 @@
 		],
 		"flint": {
 			"name": "jsdocParameterDescriptionHyphens",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"jsdocParameterDescriptions": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-param-description",
@@ -7688,10 +8250,7 @@
 		],
 		"flint": {
 			"name": "jsdocParameterDescriptions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -7701,7 +8260,7 @@
 			}
 		]
 	},
-	"jsdocParameterNames": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/check-param-names",
@@ -7710,14 +8269,11 @@
 		],
 		"flint": {
 			"name": "jsdocParameterNames",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"jsdocParameters": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-param",
@@ -7726,10 +8282,7 @@
 		],
 		"flint": {
 			"name": "jsdocParameters",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -7739,7 +8292,7 @@
 			}
 		]
 	},
-	"jsdocParameterTypes": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-param-type",
@@ -7748,10 +8301,7 @@
 		],
 		"flint": {
 			"name": "jsdocParameterTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -7761,7 +8311,7 @@
 			}
 		]
 	},
-	"jsdocProperties": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-property",
@@ -7770,10 +8320,7 @@
 		],
 		"flint": {
 			"name": "jsdocProperties",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -7783,7 +8330,7 @@
 			}
 		]
 	},
-	"jsdocPropertyDescriptions": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-property-description",
@@ -7792,10 +8339,7 @@
 		],
 		"flint": {
 			"name": "jsdocPropertyDescriptions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -7805,7 +8349,7 @@
 			}
 		]
 	},
-	"jsdocPropertyNames": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/check-property-names",
@@ -7814,10 +8358,7 @@
 		],
 		"flint": {
 			"name": "jsdocPropertyNames",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -7827,7 +8368,7 @@
 			}
 		]
 	},
-	"jsdocPropertyTypes": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-property-type",
@@ -7836,10 +8377,7 @@
 		],
 		"flint": {
 			"name": "jsdocPropertyTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -7849,7 +8387,7 @@
 			}
 		]
 	},
-	"jsdocRedundantTypes": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/no-types",
@@ -7858,14 +8396,11 @@
 		],
 		"flint": {
 			"name": "jsdocRedundantTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"jsdocRequired": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-jsdoc",
@@ -7874,14 +8409,11 @@
 		],
 		"flint": {
 			"name": "jsdocRequired",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsdocReturnDescriptions": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-returns-description",
@@ -7890,10 +8422,7 @@
 		],
 		"flint": {
 			"name": "jsdocReturnDescriptions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -7903,7 +8432,7 @@
 			}
 		]
 	},
-	"jsdocReturns": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-returns",
@@ -7912,10 +8441,7 @@
 		],
 		"flint": {
 			"name": "jsdocReturns",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -7925,7 +8451,7 @@
 			}
 		]
 	},
-	"jsdocReturnTypes": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-returns-type",
@@ -7934,10 +8460,7 @@
 		],
 		"flint": {
 			"name": "jsdocReturnTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -7947,7 +8470,7 @@
 			}
 		]
 	},
-	"jsdocTagLines": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/tag-lines",
@@ -7956,14 +8479,11 @@
 		],
 		"flint": {
 			"name": "jsdocTagLines",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsdocTagNames": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/check-tag-names",
@@ -7972,10 +8492,7 @@
 		],
 		"flint": {
 			"name": "jsdocTagNames",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -7986,23 +8503,7 @@
 			}
 		]
 	},
-	"jsdocTags": {
-		"eslint": [
-			{
-				"name": "jsdoc/sort-tags",
-				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/sort-tags.md"
-			}
-		],
-		"flint": {
-			"name": "jsdocTags",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"jsdocTemplateNames": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/check-template-names",
@@ -8011,14 +8512,11 @@
 		],
 		"flint": {
 			"name": "jsdocTemplateNames",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"jsdocTemplates": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-template",
@@ -8027,14 +8525,11 @@
 		],
 		"flint": {
 			"name": "jsdocTemplates",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsdocTextEscaping": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/text-escaping",
@@ -8043,14 +8538,11 @@
 		],
 		"flint": {
 			"name": "jsdocTextEscaping",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsdocThrows": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-throws",
@@ -8059,14 +8551,11 @@
 		],
 		"flint": {
 			"name": "jsdocThrows",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsdocTypesSyntax": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/check-syntax, jsdoc/check-types",
@@ -8075,14 +8564,11 @@
 		],
 		"flint": {
 			"name": "jsdocTypesSyntax",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"jsdocUnnecessaryReturns": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-returns-check",
@@ -8091,14 +8577,11 @@
 		],
 		"flint": {
 			"name": "jsdocUnnecessaryReturns",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"jsdocUnnecessaryYields": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-yields-check",
@@ -8107,14 +8590,11 @@
 		],
 		"flint": {
 			"name": "jsdocUnnecessaryYields",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"jsdocValidTypes": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/valid-types",
@@ -8123,14 +8603,11 @@
 		],
 		"flint": {
 			"name": "jsdocValidTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"jsdocValues": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/check-values",
@@ -8139,14 +8616,11 @@
 		],
 		"flint": {
 			"name": "jsdocValues",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"jsdocYields": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/require-yields",
@@ -8155,10 +8629,7 @@
 		],
 		"flint": {
 			"name": "jsdocYields",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -8168,7 +8639,7 @@
 			}
 		]
 	},
-	"jsonImportAttributes": {
+	{
 		"biome": [
 			{
 				"name": "useJsonImportAttributes",
@@ -8177,223 +8648,11 @@
 		],
 		"flint": {
 			"name": "jsonImportAttributes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"jsonKeys": {
-		"eslint": [
-			{
-				"name": "json/sort-keys",
-				"url": "https://github.com/eslint/json/blob/main/docs/rules/sort-keys.md"
-			},
-			{
-				"name": "jsonc/sort-keys",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/sort-keys.html"
-			}
-		],
-		"flint": {
-			"name": "jsonKeys",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"jsxProps": {
-		"eslint": [
-			{
-				"name": "perfectionist/sort-jsx-props",
-				"url": "https://perfectionist.dev/rules/sort-jsx-props"
-			}
-		],
-		"flint": {
-			"name": "jsxProps",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"keyboardEventKeys": {
-		"eslint": [
-			{
-				"name": "unicorn/prefer-keyboard-event-key",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-keyboard-event-key.md"
-			}
-		],
-		"flint": {
-			"name": "keyboardEventKeys",
-			"plugin": {
-				"code": "browser",
-				"name": "Browser"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Superseded by deprecated"
-	},
-	"keyCasing": {
-		"eslint": [
-			{
-				"name": "jsonc/key-name-casing",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/key-name-casing.html"
-			}
-		],
-		"flint": {
-			"name": "keyCasing",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"keyContents": {
-		"eslint": [
-			{
-				"name": "json/no-empty-keys",
-				"url": "https://github.com/eslint/json/blob/main/docs/rules/no-empty-keys.md"
-			}
-		],
-		"flint": {
-			"name": "keyContents",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"keyDuplicates": {
-		"deno": [
-			{
-				"name": "no-dupe-keys",
-				"url": "https://docs.deno.com/lint/rules/no-dupe-keys"
-			}
-		],
-		"eslint": [
-			{
-				"name": "jsonc/no-dupe-keys",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-dupe-keys.html"
-			}
-		],
-		"flint": {
-			"name": "keyDuplicates",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"keyNormalization": {
-		"eslint": [
-			{
-				"name": "json/no-unnormalized-keys",
-				"url": "https://github.com/eslint/json/blob/main/docs/rules/no-unnormalized-keys.md"
-			}
-		],
-		"flint": {
-			"name": "keyNormalization",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"keywordsPresence": {
-		"eslint": [
-			{
-				"name": "package-json/require-keywords",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-keywords.md"
-			}
-		],
-		"flint": {
-			"name": "keywordsPresence",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "None"
-		}
-	},
-	"keywordsValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-keywords",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-keywords.md"
-			}
-		],
-		"flint": {
-			"name": "keywordsValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"labelAssociatedControls": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/label-has-associated-control",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/label-has-associated-control.md"
-			}
-		],
-		"flint": {
-			"name": "labelAssociatedControls",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/label-has-associated-control",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/label-has-associated-control.html"
-			}
-		]
-	},
-	"labelReferences": {
-		"eslint": [
-			{
-				"name": "markdown/no-missing-label-refs",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-missing-label-refs.md"
-			}
-		],
-		"flint": {
-			"name": "labelReferences",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Logical"
-		}
-	},
-	"labelReferenceValidity": {
-		"eslint": [
-			{
-				"name": "markdown/no-invalid-label-refs",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-invalid-label-refs.md"
-			}
-		],
-		"flint": {
-			"name": "labelReferenceValidity",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Logical"
-		}
-	},
-	"labels": {
+	{
 		"biome": [
 			{
 				"name": "noConfusingLabels",
@@ -8408,10 +8667,7 @@
 		],
 		"flint": {
 			"name": "labels",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -8421,7 +8677,7 @@
 			}
 		]
 	},
-	"labelVariableNames": {
+	{
 		"biome": [
 			{
 				"name": "noLabelVar",
@@ -8436,10 +8692,7 @@
 		],
 		"flint": {
 			"name": "labelVariableNames",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -8449,94 +8702,7 @@
 			}
 		]
 	},
-	"langValidity": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/lang",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/lang.md"
-			}
-		],
-		"flint": {
-			"name": "langValidity",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical",
-			"strictness": "Strict"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/lang",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/lang.html"
-			}
-		]
-	},
-	"licenseRequired": {
-		"eslint": [
-			{
-				"name": "package-json/license-required",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/license-required.md"
-			}
-		],
-		"flint": {
-			"name": "licenseRequired",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"licenseValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-license",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-license.md"
-			}
-		],
-		"flint": {
-			"name": "licenseValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"linkContents": {
-		"eslint": [
-			{
-				"name": "markdown/no-empty-links",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-empty-links.md"
-			}
-		],
-		"flint": {
-			"name": "linkContents",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Logical"
-		}
-	},
-	"linkFragments": {
-		"eslint": [
-			{
-				"name": "markdown/no-missing-link-fragments",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-missing-link-fragments.md"
-			}
-		],
-		"flint": {
-			"name": "linkFragments",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Logical"
-		}
-	},
-	"literalConstructorWrappers": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-bigint-literals",
@@ -8545,15 +8711,12 @@
 		],
 		"flint": {
 			"name": "literalConstructorWrappers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"notes": "Will apply to all literals, not just bigint"
 	},
-	"loopAwaits": {
+	{
 		"biome": [
 			{
 				"name": "noAwaitInLoops",
@@ -8574,10 +8737,7 @@
 		],
 		"flint": {
 			"name": "loopAwaits",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "None"
 		},
 		"oxlint": [
@@ -8587,7 +8747,7 @@
 			}
 		]
 	},
-	"loopConditionConstants": {
+	{
 		"eslint": [
 			{
 				"name": "no-unmodified-loop-condition",
@@ -8596,14 +8756,11 @@
 		],
 		"flint": {
 			"name": "loopConditionConstants",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"loopFunctions": {
+	{
 		"eslint": [
 			{
 				"name": "no-loop-func",
@@ -8616,14 +8773,11 @@
 		],
 		"flint": {
 			"name": "loopFunctions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "None"
 		}
 	},
-	"magicNumbers": {
+	{
 		"biome": [
 			{
 				"name": "noMagicNumbers",
@@ -8642,10 +8796,7 @@
 		],
 		"flint": {
 			"name": "magicNumbers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -8655,87 +8806,7 @@
 			}
 		]
 	},
-	"mainValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-main",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-main.md"
-			}
-		],
-		"flint": {
-			"name": "mainValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"manValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-man",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-man.md"
-			}
-		],
-		"flint": {
-			"name": "manValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"mappedObjectSpreads": {
-		"flint": {
-			"name": "mappedObjectSpreads",
-			"plugin": {
-				"code": "performance",
-				"name": "Performance"
-			},
-			"preset": "Not implementing"
-		},
-		"oxlint": [
-			{
-				"name": "oxc/no-map-spread",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/oxc/no-map-spread.html"
-			}
-		]
-	},
-	"mappingKeyCasing": {
-		"eslint": [
-			{
-				"name": "yml/key-name-casing",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/key-name-casing.html"
-			}
-		],
-		"flint": {
-			"name": "mappingKeyCasing",
-			"plugin": {
-				"code": "yml",
-				"name": "YML"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"maps": {
-		"eslint": [
-			{
-				"name": "perfectionist/sort-maps",
-				"url": "https://perfectionist.dev/rules/sort-maps"
-			}
-		],
-		"flint": {
-			"name": "maps",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"mathMethods": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-modern-math-apis",
@@ -8744,10 +8815,7 @@
 		],
 		"flint": {
 			"name": "mathMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -8758,7 +8826,7 @@
 			}
 		]
 	},
-	"mathRangeTernaries": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-math-min-max",
@@ -8767,10 +8835,7 @@
 		],
 		"flint": {
 			"name": "mathRangeTernaries",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -8780,7 +8845,7 @@
 			}
 		]
 	},
-	"mathTruncationOperators": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-math-trunc",
@@ -8789,10 +8854,7 @@
 		],
 		"flint": {
 			"name": "mathTruncationOperators",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -8802,7 +8864,7 @@
 			}
 		]
 	},
-	"maximumClassesPerFile": {
+	{
 		"eslint": [
 			{
 				"name": "max-classes-per-file",
@@ -8811,10 +8873,7 @@
 		],
 		"flint": {
 			"name": "maximumClassesPerFile",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -8824,7 +8883,7 @@
 			}
 		]
 	},
-	"maximumComplexity": {
+	{
 		"eslint": [
 			{
 				"name": "complexity",
@@ -8833,14 +8892,11 @@
 		],
 		"flint": {
 			"name": "maximumComplexity",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"maximumDepth": {
+	{
 		"eslint": [
 			{
 				"name": "max-depth",
@@ -8849,10 +8905,7 @@
 		],
 		"flint": {
 			"name": "maximumDepth",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -8862,7 +8915,7 @@
 			}
 		]
 	},
-	"maximumIdentifierLengths": {
+	{
 		"eslint": [
 			{
 				"name": "id-length",
@@ -8871,10 +8924,7 @@
 		],
 		"flint": {
 			"name": "maximumIdentifierLengths",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -8884,7 +8934,7 @@
 			}
 		]
 	},
-	"maximumLinesPerFile": {
+	{
 		"eslint": [
 			{
 				"name": "max-lines",
@@ -8893,10 +8943,7 @@
 		],
 		"flint": {
 			"name": "maximumLinesPerFile",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -8906,7 +8953,7 @@
 			}
 		]
 	},
-	"maximumLinesPerFunction": {
+	{
 		"biome": [
 			{
 				"name": "noExcessiveLinesPerFunction",
@@ -8921,10 +8968,7 @@
 		],
 		"flint": {
 			"name": "maximumLinesPerFunction",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -8934,7 +8978,7 @@
 			}
 		]
 	},
-	"maximumNestedCallbacks": {
+	{
 		"eslint": [
 			{
 				"name": "max-nested-callbacks",
@@ -8943,10 +8987,7 @@
 		],
 		"flint": {
 			"name": "maximumNestedCallbacks",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -8956,7 +8997,7 @@
 			}
 		]
 	},
-	"maximumParameters": {
+	{
 		"biome": [
 			{
 				"name": "useMaxParams",
@@ -8975,10 +9016,7 @@
 		],
 		"flint": {
 			"name": "maximumParameters",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -8988,7 +9026,7 @@
 			}
 		]
 	},
-	"maximumStatements": {
+	{
 		"eslint": [
 			{
 				"name": "max-statements",
@@ -8997,14 +9035,11 @@
 		],
 		"flint": {
 			"name": "maximumStatements",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"meaninglessVoidOperators": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-meaningless-void-operator",
@@ -9013,10 +9048,7 @@
 		],
 		"flint": {
 			"name": "meaninglessVoidOperators",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -9026,45 +9058,7 @@
 			}
 		]
 	},
-	"mediaCaptions": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/media-has-caption",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/media-has-caption.md"
-			}
-		],
-		"flint": {
-			"name": "mediaCaptions",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/media-has-caption",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/media-has-caption.html"
-			}
-		]
-	},
-	"mediaSyntaxReversals": {
-		"eslint": [
-			{
-				"name": "markdown/no-reversed-media-syntax",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-reversed-media-syntax.md"
-			}
-		],
-		"flint": {
-			"name": "mediaSyntaxReversals",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"memberAccessibility": {
+	{
 		"biome": [
 			{
 				"name": "useConsistentMemberAccessibility",
@@ -9079,40 +9073,18 @@
 		],
 		"flint": {
 			"name": "memberAccessibility",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"misleadingSemicolons": {
-		"biome": [
-			{
-				"name": "noSuspiciousSemicolonInJsx",
-				"url": "https://biomejs.dev/linter/rules/noSuspiciousSemicolonInJsx"
-			}
-		],
-		"flint": {
-			"name": "misleadingSemicolons",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"misleadingShorthandAssignments": {
+	{
 		"flint": {
 			"name": "misleadingShorthandAssignments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"misleadingThenProperties": {
+	{
 		"biome": [
 			{
 				"name": "noThenProperty",
@@ -9127,10 +9099,7 @@
 		],
 		"flint": {
 			"name": "misleadingThenProperties",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -9140,7 +9109,7 @@
 			}
 		]
 	},
-	"misleadingVoidExpressions": {
+	{
 		"biome": [
 			{
 				"name": "noVoidTypeReturn",
@@ -9155,10 +9124,7 @@
 		],
 		"flint": {
 			"name": "misleadingVoidExpressions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -9168,39 +9134,7 @@
 			}
 		]
 	},
-	"missingImports": {
-		"eslint": [
-			{
-				"name": "n/no-missing-import",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-missing-import.md"
-			}
-		],
-		"flint": {
-			"name": "missingImports",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"missingRequires": {
-		"eslint": [
-			{
-				"name": "n/no-missing-require",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-missing-require.md"
-			}
-		],
-		"flint": {
-			"name": "missingRequires",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"misusedPromises": {
+	{
 		"biome": [
 			{
 				"name": "noMisusedPromises",
@@ -9215,10 +9149,7 @@
 		],
 		"flint": {
 			"name": "misusedPromises",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -9228,24 +9159,7 @@
 			}
 		]
 	},
-	"mixedRequires": {
-		"eslint": [
-			{
-				"name": "n/no-mixed-requires",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-mixed-requires.md"
-			}
-		],
-		"flint": {
-			"name": "mixedRequires",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Superseded by ESM and ordering rules"
-	},
-	"moduleBoundaryTypes": {
+	{
 		"biome": [
 			{
 				"name": "useExplicitType",
@@ -9266,10 +9180,7 @@
 		],
 		"flint": {
 			"name": "moduleBoundaryTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -9279,7 +9190,7 @@
 			}
 		]
 	},
-	"moduleFormats": {
+	{
 		"biome": [
 			{
 				"name": "noGlobalDirnameFilename",
@@ -9294,14 +9205,11 @@
 		],
 		"flint": {
 			"name": "moduleFormats",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"moduleImportStyles": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/import-style",
@@ -9310,30 +9218,11 @@
 		],
 		"flint": {
 			"name": "moduleImportStyles",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"modules": {
-		"eslint": [
-			{
-				"name": "perfectionist/sort-modules",
-				"url": "https://perfectionist.dev/rules/sort-modules"
-			}
-		],
-		"flint": {
-			"name": "modules",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"moduleSpecifierLists": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/require-module-specifiers",
@@ -9342,36 +9231,11 @@
 		],
 		"flint": {
 			"name": "moduleSpecifierLists",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"mouseEventKeyEvents": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/mouse-events-have-key-events",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/mouse-events-have-key-events.md"
-			}
-		],
-		"flint": {
-			"name": "mouseEventKeyEvents",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/mouse-events-have-key-events",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/mouse-events-have-key-events.html"
-			}
-		]
-	},
-	"multilineAmbiguities": {
+	{
 		"eslint": [
 			{
 				"name": "no-unexpected-multiline",
@@ -9380,10 +9244,7 @@
 		],
 		"flint": {
 			"name": "multilineAmbiguities",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -9393,7 +9254,7 @@
 			}
 		]
 	},
-	"multilineStrings": {
+	{
 		"eslint": [
 			{
 				"name": "no-multi-str",
@@ -9402,10 +9263,7 @@
 		],
 		"flint": {
 			"name": "multilineStrings",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -9415,7 +9273,7 @@
 			}
 		]
 	},
-	"multipleElseIfSwitches": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-switch",
@@ -9424,14 +9282,11 @@
 		],
 		"flint": {
 			"name": "multipleElseIfSwitches",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"namedDefaultExports": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-anonymous-default-export",
@@ -9440,10 +9295,7 @@
 		],
 		"flint": {
 			"name": "namedDefaultExports",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -9458,23 +9310,7 @@
 			}
 		]
 	},
-	"namePresence": {
-		"eslint": [
-			{
-				"name": "package-json/require-name",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-name.md"
-			}
-		],
-		"flint": {
-			"name": "namePresence",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"namespaceDeclarations": {
+	{
 		"biome": [
 			{
 				"name": "noNamespace",
@@ -9496,10 +9332,7 @@
 		"flint": {
 			"implemented": true,
 			"name": "namespaceDeclarations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -9509,7 +9342,7 @@
 			}
 		]
 	},
-	"namespaceImplicitAmbientImports": {
+	{
 		"deno": [
 			{
 				"name": "no-implicit-declare-namespace-export",
@@ -9518,15 +9351,12 @@
 		],
 		"flint": {
 			"name": "namespaceImplicitAmbientImports",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"namespaceKeywords": {
+	{
 		"biome": [
 			{
 				"name": "useNamespaceKeyword",
@@ -9547,10 +9377,7 @@
 		],
 		"flint": {
 			"name": "namespaceKeywords",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -9560,23 +9387,7 @@
 			}
 		]
 	},
-	"nameValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-name",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-name.md"
-			}
-		],
-		"flint": {
-			"name": "nameValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"namingConventions": {
+	{
 		"biome": [
 			{
 				"name": "useNamingConvention",
@@ -9601,31 +9412,11 @@
 		],
 		"flint": {
 			"name": "namingConventions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"nan": {
-		"eslint": [
-			{
-				"name": "jsonc/no-nan",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-nan.html"
-			}
-		],
-		"flint": {
-			"name": "nan",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"nativeObjectExtensions": {
+	{
 		"eslint": [
 			{
 				"name": "no-extend-native",
@@ -9634,10 +9425,7 @@
 		],
 		"flint": {
 			"name": "nativeObjectExtensions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -9647,7 +9435,7 @@
 			}
 		]
 	},
-	"negativeIndexLengthMethods": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-negative-index",
@@ -9656,15 +9444,12 @@
 		],
 		"flint": {
 			"name": "negativeIndexLengthMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"negativeZeroComparisons": {
+	{
 		"biome": [
 			{
 				"name": "noCompareNegZero",
@@ -9685,10 +9470,7 @@
 		],
 		"flint": {
 			"name": "negativeZeroComparisons",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -9698,7 +9480,7 @@
 			}
 		]
 	},
-	"nestedStandaloneIfs": {
+	{
 		"biome": [
 			{
 				"name": "useCollapsedElseIf",
@@ -9721,10 +9503,7 @@
 		],
 		"flint": {
 			"name": "nestedStandaloneIfs",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -9738,7 +9517,7 @@
 			}
 		]
 	},
-	"newDefinitions": {
+	{
 		"biome": [
 			{
 				"name": "noMisleadingInstantiator",
@@ -9759,10 +9538,7 @@
 		],
 		"flint": {
 			"name": "newDefinitions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -9772,19 +9548,13 @@
 			}
 		]
 	},
-	"newExpressions": {
+	{
 		"eslint": [
-			{
-				"name": "no-new",
-				"url": "https://eslint.org/docs/latest/rules/no-new"
-			}
+			{ "name": "no-new", "url": "https://eslint.org/docs/latest/rules/no-new" }
 		],
 		"flint": {
 			"name": "newExpressions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"notes": "oxc/missing-throw is a subset",
@@ -9799,7 +9569,7 @@
 			}
 		]
 	},
-	"newNativeNonConstructors": {
+	{
 		"biome": [
 			{
 				"name": "noInvalidBuiltinInstantiation",
@@ -9820,10 +9590,7 @@
 		],
 		"flint": {
 			"name": "newNativeNonConstructors",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -9833,273 +9600,7 @@
 			}
 		]
 	},
-	"newRequires": {
-		"eslint": [
-			{
-				"name": "n/no-new-requires",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-new-requires.md"
-			}
-		],
-		"flint": {
-			"name": "newRequires",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		},
-		"oxlint": [
-			{
-				"name": "node/no-new-require",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/node/no-new-require.html"
-			}
-		]
-	},
-	"nodeAppendMethods": {
-		"eslint": [
-			{
-				"name": "unicorn/prefer-dom-node-append",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-append.md"
-			}
-		],
-		"flint": {
-			"name": "nodeAppendMethods",
-			"plugin": {
-				"code": "browser",
-				"name": "Browser"
-			},
-			"preset": "Logical",
-			"strictness": "Strict"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/prefer-dom-node-append",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-dom-node-append.html"
-			}
-		]
-	},
-	"nodeDatasetAttributes": {
-		"eslint": [
-			{
-				"name": "unicorn/prefer-dom-node-dataset",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-dataset.md"
-			}
-		],
-		"flint": {
-			"name": "nodeDatasetAttributes",
-			"plugin": {
-				"code": "browser",
-				"name": "Browser"
-			},
-			"preset": "Logical",
-			"strictness": "Strict"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/prefer-dom-node-dataset",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-dom-node-dataset.html"
-			}
-		]
-	},
-	"nodeGlobals": {
-		"deno": [
-			{
-				"name": "no-node-globals",
-				"url": "https://docs.deno.com/lint/rules/no-node-globals"
-			}
-		],
-		"flint": {
-			"name": "nodeGlobals",
-			"plugin": {
-				"code": "deno",
-				"name": "Deno"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"nodeModificationMethods": {
-		"eslint": [
-			{
-				"name": "unicorn/prefer-modern-dom-apis",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-modern-dom-apis.md"
-			}
-		],
-		"flint": {
-			"name": "nodeModificationMethods",
-			"plugin": {
-				"code": "browser",
-				"name": "Browser"
-			},
-			"preset": "Logical",
-			"strictness": "Strict"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/prefer-modern-dom-apis",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-modern-dom-apis.html"
-			}
-		]
-	},
-	"nodeProtocols": {
-		"biome": [
-			{
-				"name": "useNodejsImportProtocol",
-				"url": "https://biomejs.dev/linter/rules/useNodejsImportProtocol"
-			}
-		],
-		"eslint": [
-			{
-				"name": "import/enforce-node-protocol-usage",
-				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/enforce-node-protocol-usage.md"
-			},
-			{
-				"name": "n/prefer-node-protocol",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-node-protocol.md"
-			},
-			{
-				"name": "unicorn/prefer-node-protocol",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md"
-			}
-		],
-		"flint": {
-			"name": "nodeProtocols",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/prefer-node-protocol",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-node-protocol.html"
-			}
-		]
-	},
-	"nodeQueryMethods": {
-		"eslint": [
-			{
-				"name": "unicorn/prefer-query-selector",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-query-selector.md"
-			}
-		],
-		"flint": {
-			"name": "nodeQueryMethods",
-			"plugin": {
-				"code": "browser",
-				"name": "Browser"
-			},
-			"preset": "Stylistic",
-			"strictness": "Strict"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/prefer-query-selector",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-query-selector.html"
-			}
-		]
-	},
-	"nodeRemoveMethods": {
-		"eslint": [
-			{
-				"name": "unicorn/prefer-dom-node-remove",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-remove.md"
-			}
-		],
-		"flint": {
-			"name": "nodeRemoveMethods",
-			"plugin": {
-				"code": "browser",
-				"name": "Browser"
-			},
-			"preset": "Logical",
-			"strictness": "Strict"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/prefer-dom-node-remove",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-dom-node-remove.html"
-			}
-		]
-	},
-	"nodeTextContents": {
-		"eslint": [
-			{
-				"name": "unicorn/prefer-dom-node-text-content",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-text-content.md"
-			}
-		],
-		"flint": {
-			"name": "nodeTextContents",
-			"plugin": {
-				"code": "browser",
-				"name": "Browser"
-			},
-			"preset": "Logical",
-			"strictness": "Strict"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/prefer-dom-node-text-content",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-dom-node-text-content.html"
-			}
-		]
-	},
-	"nonInteractiveElementInteractions": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/no-noninteractive-element-interactions",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-element-interactions.md"
-			}
-		],
-		"flint": {
-			"name": "nonInteractiveElementInteractions",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		}
-	},
-	"nonInteractiveElementInteractiveRoles": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/no-noninteractive-element-to-interactive-role",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-element-to-interactive-role.md"
-			}
-		],
-		"flint": {
-			"name": "nonInteractiveElementInteractiveRoles",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		}
-	},
-	"nonInteractiveElementTabIndexes": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/no-noninteractive-tabindex",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-tabindex.md"
-			}
-		],
-		"flint": {
-			"name": "nonInteractiveElementTabIndexes",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/no-noninteractive-tabindex",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/no-noninteractive-tabindex.html"
-			}
-		]
-	},
-	"nonNullableTypeAssertions": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/non-nullable-type-assertion-style",
@@ -10108,10 +9609,7 @@
 		],
 		"flint": {
 			"name": "nonNullableTypeAssertions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -10121,7 +9619,7 @@
 			}
 		]
 	},
-	"nonNullAssertedNullishCoalesces": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-non-null-asserted-nullish-coalescing",
@@ -10130,10 +9628,7 @@
 		],
 		"flint": {
 			"name": "nonNullAssertedNullishCoalesces",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		},
@@ -10144,7 +9639,7 @@
 			}
 		]
 	},
-	"nonNullAssertedOptionalChains": {
+	{
 		"biome": [
 			{
 				"name": "noNonNullAssertedOptionalChain",
@@ -10165,10 +9660,7 @@
 		],
 		"flint": {
 			"name": "nonNullAssertedOptionalChains",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -10178,7 +9670,7 @@
 			}
 		]
 	},
-	"nonNullAssertionPlacement": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-confusing-non-null-assertion",
@@ -10187,10 +9679,7 @@
 		],
 		"flint": {
 			"name": "nonNullAssertionPlacement",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -10201,7 +9690,7 @@
 			}
 		]
 	},
-	"nonNullAssertions": {
+	{
 		"biome": [
 			{
 				"name": "noNonNullAssertion",
@@ -10222,10 +9711,7 @@
 		],
 		"flint": {
 			"name": "nonNullAssertions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		},
@@ -10236,7 +9722,7 @@
 			}
 		]
 	},
-	"nonOctalDecimalEscapes": {
+	{
 		"biome": [
 			{
 				"name": "noNonoctalDecimalEscape",
@@ -10251,10 +9737,7 @@
 		],
 		"flint": {
 			"name": "nonOctalDecimalEscapes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -10264,7 +9747,7 @@
 			}
 		]
 	},
-	"nullComparisons": {
+	{
 		"eslint": [
 			{
 				"name": "no-eq-null",
@@ -10273,10 +9756,7 @@
 		],
 		"flint": {
 			"name": "nullComparisons",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -10286,7 +9766,7 @@
 			}
 		]
 	},
-	"nullishCoalescingOperators": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/prefer-nullish-coalescing",
@@ -10295,14 +9775,11 @@
 		],
 		"flint": {
 			"name": "nullishCoalescingOperators",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"nulls": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-null",
@@ -10311,10 +9788,7 @@
 		],
 		"flint": {
 			"name": "nulls",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -10324,7 +9798,7 @@
 			}
 		]
 	},
-	"numberKeyLiterals": {
+	{
 		"biome": [
 			{
 				"name": "useSimpleNumberKeys",
@@ -10333,20 +9807,14 @@
 		],
 		"flint": {
 			"name": "numberKeyLiterals",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"numberMethodRanges": {
+	{
 		"flint": {
 			"name": "numberMethodRanges",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -10356,24 +9824,7 @@
 			}
 		]
 	},
-	"numbers": {
-		"eslint": [
-			{
-				"name": "jsonc/valid-json-number",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/valid-json-number.html"
-			}
-		],
-		"flint": {
-			"name": "numbers",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"numberStaticMethods": {
+	{
 		"biome": [
 			{
 				"name": "noGlobalIsFinite",
@@ -10392,10 +9843,7 @@
 		],
 		"flint": {
 			"name": "numberStaticMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -10406,7 +9854,7 @@
 			}
 		]
 	},
-	"numberToFixedDigits": {
+	{
 		"biome": [
 			{
 				"name": "useNumberToFixedDigitsArgument",
@@ -10421,10 +9869,7 @@
 		],
 		"flint": {
 			"name": "numberToFixedDigits",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -10434,7 +9879,7 @@
 			}
 		]
 	},
-	"numericConstantApproximations": {
+	{
 		"biome": [
 			{
 				"name": "noApproximativeNumericConstant",
@@ -10443,10 +9888,7 @@
 		],
 		"flint": {
 			"name": "numericConstantApproximations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -10456,13 +9898,10 @@
 			}
 		]
 	},
-	"numericErasingOperations": {
+	{
 		"flint": {
 			"name": "numericErasingOperations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -10472,7 +9911,7 @@
 			}
 		]
 	},
-	"numericLiteralCasing": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/number-literal-case",
@@ -10481,10 +9920,7 @@
 		],
 		"flint": {
 			"name": "numericLiteralCasing",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -10495,7 +9931,7 @@
 			}
 		]
 	},
-	"numericLiteralParsing": {
+	{
 		"biome": [
 			{
 				"name": "useNumericLiterals",
@@ -10510,10 +9946,7 @@
 		],
 		"flint": {
 			"name": "numericLiteralParsing",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -10523,7 +9956,7 @@
 			}
 		]
 	},
-	"numericPrecision": {
+	{
 		"biome": [
 			{
 				"name": "noPrecisionLoss",
@@ -10542,10 +9975,7 @@
 		],
 		"flint": {
 			"name": "numericPrecision",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -10555,7 +9985,7 @@
 			}
 		]
 	},
-	"numericSeparatorGroups": {
+	{
 		"biome": [
 			{
 				"name": "useNumericSeparators",
@@ -10570,10 +10000,7 @@
 		],
 		"flint": {
 			"name": "numericSeparatorGroups",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -10584,41 +10011,7 @@
 			}
 		]
 	},
-	"numericSeparators": {
-		"eslint": [
-			{
-				"name": "jsonc/no-numeric-separators",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-numeric-separators.html"
-			}
-		],
-		"flint": {
-			"name": "numericSeparators",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"numericTrailingZeros": {
-		"eslint": [
-			{
-				"name": "yml/no-trailing-zeros",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-trailing-zeros.html"
-			}
-		],
-		"flint": {
-			"name": "numericTrailingZeros",
-			"plugin": {
-				"code": "yml",
-				"name": "YML"
-			},
-			"preset": "Stylistic",
-			"strictness": "Strict"
-		}
-	},
-	"objectAssignSpreads": {
+	{
 		"biome": [
 			{
 				"name": "useObjectSpread",
@@ -10633,10 +10026,7 @@
 		],
 		"flint": {
 			"name": "objectAssignSpreads",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -10646,7 +10036,7 @@
 			}
 		]
 	},
-	"objectCalls": {
+	{
 		"eslint": [
 			{
 				"name": "no-object-constructor",
@@ -10655,10 +10045,7 @@
 		],
 		"flint": {
 			"name": "objectCalls",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -10668,7 +10055,7 @@
 			}
 		]
 	},
-	"objectDefaultParameters": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-object-as-default-parameter",
@@ -10677,10 +10064,7 @@
 		],
 		"flint": {
 			"name": "objectDefaultParameters",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -10690,7 +10074,7 @@
 			}
 		]
 	},
-	"objectEntriesMethods": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-object-from-entries",
@@ -10699,10 +10083,7 @@
 		],
 		"flint": {
 			"name": "objectEntriesMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -10713,7 +10094,7 @@
 			}
 		]
 	},
-	"objectHasOwns": {
+	{
 		"biome": [
 			{
 				"name": "noPrototypeBuiltins",
@@ -10728,10 +10109,7 @@
 		],
 		"flint": {
 			"name": "objectHasOwns",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -10741,7 +10119,7 @@
 			}
 		]
 	},
-	"objectKeyDuplicates": {
+	{
 		"biome": [
 			{
 				"name": "noDuplicateObjectKeys",
@@ -10756,20 +10134,14 @@
 		],
 		"flint": {
 			"name": "objectKeyDuplicates",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"objectLiteralComparisons": {
+	{
 		"flint": {
 			"name": "objectLiteralComparisons",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -10779,7 +10151,7 @@
 			}
 		]
 	},
-	"objectProto": {
+	{
 		"eslint": [
 			{
 				"name": "no-proto",
@@ -10788,10 +10160,7 @@
 		],
 		"flint": {
 			"name": "objectProto",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -10801,7 +10170,7 @@
 			}
 		]
 	},
-	"objectPrototypeBuiltIns": {
+	{
 		"biome": [
 			{
 				"name": "noPrototypeBuiltins",
@@ -10822,10 +10191,7 @@
 		],
 		"flint": {
 			"name": "objectPrototypeBuiltIns",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -10835,33 +10201,7 @@
 			}
 		]
 	},
-	"objects": {
-		"eslint": [
-			{
-				"name": "sort-keys",
-				"url": "https://eslint.org/docs/latest/rules/sort-keys"
-			},
-			{
-				"name": "perfectionist/sort-objects",
-				"url": "https://perfectionist.dev/rules/sort-objects"
-			}
-		],
-		"flint": {
-			"name": "objects",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		},
-		"oxlint": [
-			{
-				"name": "eslint/sort-keys",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/sort-keys.html"
-			}
-		]
-	},
-	"objectShorthand": {
+	{
 		"biome": [
 			{
 				"name": "useConsistentObjectDefinitions",
@@ -10876,14 +10216,11 @@
 		],
 		"flint": {
 			"name": "objectShorthand",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"objectSpreadUnnecessaryFallbacks": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-useless-fallback-in-spread",
@@ -10892,10 +10229,7 @@
 		],
 		"flint": {
 			"name": "objectSpreadUnnecessaryFallbacks",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -10905,7 +10239,7 @@
 			}
 		]
 	},
-	"objectTypeDefinitions": {
+	{
 		"biome": [
 			{
 				"name": "useConsistentTypeDefinitions",
@@ -10920,10 +10254,7 @@
 		],
 		"flint": {
 			"name": "objectTypeDefinitions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -10933,23 +10264,7 @@
 			}
 		]
 	},
-	"objectTypes": {
-		"eslint": [
-			{
-				"name": "perfectionist/sort-object-types",
-				"url": "https://perfectionist.dev/rules/sort-object-types"
-			}
-		],
-		"flint": {
-			"name": "objectTypes",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"octalEscapes": {
+	{
 		"biome": [
 			{
 				"name": "noOctalEscape",
@@ -10957,10 +10272,7 @@
 			}
 		],
 		"deno": [
-			{
-				"name": "no-octal",
-				"url": "https://docs.deno.com/lint/rules/no-octal"
-			}
+			{ "name": "no-octal", "url": "https://docs.deno.com/lint/rules/no-octal" }
 		],
 		"eslint": [
 			{
@@ -10970,48 +10282,11 @@
 		],
 		"flint": {
 			"name": "octalEscapes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		}
 	},
-	"octalEscapeSequences": {
-		"eslint": [
-			{
-				"name": "jsonc/no-octal-escape",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-escape.html"
-			}
-		],
-		"flint": {
-			"name": "octalEscapeSequences",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"octalLiterals": {
-		"eslint": [
-			{
-				"name": "jsonc/no-octal-escape",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-escape.html"
-			}
-		],
-		"flint": {
-			"name": "octalLiterals",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"octalNumbers": {
+	{
 		"eslint": [
 			{
 				"name": "no-octal",
@@ -11020,31 +10295,11 @@
 		],
 		"flint": {
 			"name": "octalNumbers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		}
 	},
-	"octalNumericLiterals": {
-		"eslint": [
-			{
-				"name": "jsonc/no-octal-numeric-literals",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-numeric-literals.html"
-			}
-		],
-		"flint": {
-			"name": "octalNumericLiterals",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"operatorAssignmentShorthand": {
+	{
 		"biome": [
 			{
 				"name": "useShorthandAssign",
@@ -11059,10 +10314,7 @@
 		],
 		"flint": {
 			"name": "operatorAssignmentShorthand",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -11072,13 +10324,10 @@
 			}
 		]
 	},
-	"optionalChainExpressions": {
+	{
 		"flint": {
 			"name": "optionalChainExpressions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -11088,7 +10337,7 @@
 			}
 		]
 	},
-	"optionalChainOperators": {
+	{
 		"biome": [
 			{
 				"name": "useOptionalChain",
@@ -11103,62 +10352,11 @@
 		],
 		"flint": {
 			"name": "optionalChainOperators",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"optionalDependenciesPresence": {
-		"eslint": [
-			{
-				"name": "package-json/require-optionalDependencies",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-optionalDependencies.md"
-			}
-		],
-		"flint": {
-			"name": "optionalDependenciesPresence",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "None"
-		}
-	},
-	"optionalDependenciesValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-optionalDependencies",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-optionalDependencies.md"
-			}
-		],
-		"flint": {
-			"name": "optionalDependenciesValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"osValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-os",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-os.md"
-			}
-		],
-		"flint": {
-			"name": "osValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"overloadSignaturesAdjacent": {
+	{
 		"biome": [
 			{
 				"name": "useAdjacentOverloadSignatures",
@@ -11179,10 +10377,7 @@
 		],
 		"flint": {
 			"name": "overloadSignaturesAdjacent",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -11192,23 +10387,7 @@
 			}
 		]
 	},
-	"packageCollections": {
-		"eslint": [
-			{
-				"name": "package-json/sort-collections",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/sort-collections.md"
-			}
-		],
-		"flint": {
-			"name": "packageCollections",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"parameterProperties": {
+	{
 		"biome": [
 			{
 				"name": "noParameterProperties",
@@ -11227,14 +10406,11 @@
 		],
 		"flint": {
 			"name": "parameterProperties",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"parameterPropertyAssignment": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
@@ -11243,10 +10419,7 @@
 		],
 		"flint": {
 			"name": "parameterPropertyAssignment",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -11256,7 +10429,7 @@
 			}
 		]
 	},
-	"parameterReassignments": {
+	{
 		"biome": [
 			{
 				"name": "noParameterAssign",
@@ -11271,32 +10444,12 @@
 		],
 		"flint": {
 			"name": "parameterReassignments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"parentheses": {
-		"eslint": [
-			{
-				"name": "jsonc/no-parenthesized",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-parenthesized.html"
-			}
-		],
-		"flint": {
-			"name": "parentheses",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"parseIntRadixes": {
+	{
 		"biome": [
 			{
 				"name": "useParseIntRadix",
@@ -11304,17 +10457,11 @@
 			}
 		],
 		"eslint": [
-			{
-				"name": "radix",
-				"url": "https://eslint.org/docs/latest/rules/radix"
-			}
+			{ "name": "radix", "url": "https://eslint.org/docs/latest/rules/radix" }
 		],
 		"flint": {
 			"name": "parseIntRadixes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -11324,72 +10471,7 @@
 			}
 		]
 	},
-	"pathConcatenations": {
-		"eslint": [
-			{
-				"name": "n/no-path-concat",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-path-concat.md"
-			}
-		],
-		"flint": {
-			"name": "pathConcatenations",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"peerDependenciesPresence": {
-		"eslint": [
-			{
-				"name": "package-json/require-peerDependencies",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-peerDependencies.md"
-			}
-		],
-		"flint": {
-			"name": "peerDependenciesPresence",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "None"
-		}
-	},
-	"peerDependenciesValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-peerDependencies",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-peerDependencies.md"
-			}
-		],
-		"flint": {
-			"name": "peerDependenciesValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"plainScalars": {
-		"eslint": [
-			{
-				"name": "yml/plain-scalar",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/plain-scalar.html"
-			}
-		],
-		"flint": {
-			"name": "plainScalars",
-			"plugin": {
-				"code": "yml",
-				"name": "YML"
-			},
-			"preset": "Stylistic",
-			"strictness": "Strict"
-		}
-	},
-	"plusOperands": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/restrict-plus-operands",
@@ -11398,10 +10480,7 @@
 		],
 		"flint": {
 			"name": "plusOperands",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -11411,24 +10490,7 @@
 			}
 		]
 	},
-	"plusOperators": {
-		"eslint": [
-			{
-				"name": "jsonc/no-plus-sign",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-plus-sign.html"
-			}
-		],
-		"flint": {
-			"name": "plusOperators",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"plusPlusOperators": {
+	{
 		"eslint": [
 			{
 				"name": "no-plusplus",
@@ -11437,10 +10499,7 @@
 		],
 		"flint": {
 			"name": "plusPlusOperators",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -11450,7 +10509,7 @@
 			}
 		]
 	},
-	"prefixedClassLikes": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-keyword-prefix",
@@ -11459,94 +10518,14 @@
 		],
 		"flint": {
 			"name": "prefixedClassLikes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"privateValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-private",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-private.md"
-			}
-		],
-		"flint": {
-			"name": "privateValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"processEnvs": {
-		"eslint": [
-			{
-				"name": "n/no-process-env",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-process-env.md"
-			}
-		],
-		"flint": {
-			"name": "processEnvs",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"processExists": {
-		"eslint": [
-			{
-				"name": "n/no-process-exit",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-process-exit.md"
-			},
-			{
-				"name": "unicorn/no-process-exit",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-process-exit.md"
-			}
-		],
-		"flint": {
-			"name": "processExists",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/no-process-exit",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-process-exit.html"
-			}
-		]
-	},
-	"processExitThrows": {
-		"eslint": [
-			{
-				"name": "n/process-exit-as-throw",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/process-exit-as-throw.md"
-			}
-		],
-		"flint": {
-			"name": "processExitThrows",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"promiseAlwaysReturn": {
+	{
 		"flint": {
 			"name": "promiseAlwaysReturn",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Superseded by no-floating-promises",
@@ -11557,13 +10536,10 @@
 			}
 		]
 	},
-	"promiseArgumentCounts": {
+	{
 		"flint": {
 			"name": "promiseArgumentCounts",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -11573,7 +10549,7 @@
 			}
 		]
 	},
-	"promiseAwaitableCallbacks": {
+	{
 		"eslint": [
 			{
 				"name": "promise/prefer-await-to-callbacks",
@@ -11582,10 +10558,7 @@
 		],
 		"flint": {
 			"name": "promiseAwaitableCallbacks",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -11595,7 +10568,7 @@
 			}
 		]
 	},
-	"promiseAwaitableThens": {
+	{
 		"eslint": [
 			{
 				"name": "promise/prefer-await-to-then",
@@ -11604,10 +10577,7 @@
 		],
 		"flint": {
 			"name": "promiseAwaitableThens",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -11617,29 +10587,7 @@
 			}
 		]
 	},
-	"promiseCallbackFunctions": {
-		"eslint": [
-			{
-				"name": "promise/no-callback-in-promise",
-				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/HEAD/docs/rules/no-callback-in-promise.md"
-			}
-		],
-		"flint": {
-			"name": "promiseCallbackFunctions",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		},
-		"oxlint": [
-			{
-				"name": "promise/no-callback-in-promise",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/promise/no-callback-in-promise.html"
-			}
-		]
-	},
-	"promiseCatchableThens": {
+	{
 		"eslint": [
 			{
 				"name": "promise/prefer-catch",
@@ -11648,10 +10596,7 @@
 		],
 		"flint": {
 			"name": "promiseCatchableThens",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -11661,13 +10606,10 @@
 			}
 		]
 	},
-	"promiseCatchOrReturn": {
+	{
 		"flint": {
 			"name": "promiseCatchOrReturn",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Superseded by no-floating-promises",
@@ -11678,13 +10620,10 @@
 			}
 		]
 	},
-	"promiseErrorFirstCallbacks": {
+	{
 		"flint": {
 			"name": "promiseErrorFirstCallbacks",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Superseded by no-floating-promises",
@@ -11695,7 +10634,7 @@
 			}
 		]
 	},
-	"promiseExecutorReturns": {
+	{
 		"eslint": [
 			{
 				"name": "no-promise-executor-return",
@@ -11704,14 +10643,11 @@
 		],
 		"flint": {
 			"name": "promiseExecutorReturns",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"promiseFinallyReturns": {
+	{
 		"eslint": [
 			{
 				"name": "promise/no-return-in-finally",
@@ -11720,10 +10656,7 @@
 		],
 		"flint": {
 			"name": "promiseFinallyReturns",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -11733,7 +10666,7 @@
 			}
 		]
 	},
-	"promiseFunctionAsync": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/promise-function-async",
@@ -11742,10 +10675,7 @@
 		],
 		"flint": {
 			"name": "promiseFunctionAsync",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -11755,7 +10685,7 @@
 			}
 		]
 	},
-	"promiseMethodSingleArrayArguments": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-single-promise-in-promise-methods",
@@ -11764,10 +10694,7 @@
 		],
 		"flint": {
 			"name": "promiseMethodSingleArrayArguments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -11777,7 +10704,7 @@
 			}
 		]
 	},
-	"promiseNesting": {
+	{
 		"eslint": [
 			{
 				"name": "promise/no-nesting",
@@ -11786,10 +10713,7 @@
 		],
 		"flint": {
 			"name": "promiseNesting",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -11799,7 +10723,7 @@
 			}
 		]
 	},
-	"promiseNews": {
+	{
 		"eslint": [
 			{
 				"name": "promise/avoid-new",
@@ -11808,10 +10732,7 @@
 		],
 		"flint": {
 			"name": "promiseNews",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -11821,13 +10742,10 @@
 			}
 		]
 	},
-	"promiseNewStatics": {
+	{
 		"flint": {
 			"name": "promiseNewStatics",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -11837,13 +10755,10 @@
 			}
 		]
 	},
-	"promiseNonSpecMethods": {
+	{
 		"flint": {
 			"name": "promiseNonSpecMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Superseded by no-floating-promises",
@@ -11854,7 +10769,7 @@
 			}
 		]
 	},
-	"promiseParameterNames": {
+	{
 		"eslint": [
 			{
 				"name": "promise/param-names",
@@ -11863,10 +10778,7 @@
 		],
 		"flint": {
 			"name": "promiseParameterNames",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -11876,7 +10788,7 @@
 			}
 		]
 	},
-	"promiseRejectErrors": {
+	{
 		"eslint": [
 			{
 				"name": "prefer-promise-reject-errors",
@@ -11889,10 +10801,7 @@
 		],
 		"flint": {
 			"name": "promiseRejectErrors",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -11906,39 +10815,7 @@
 			}
 		]
 	},
-	"promisesDNS": {
-		"eslint": [
-			{
-				"name": "n/prefer-promises/dns",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-promises.md"
-			}
-		],
-		"flint": {
-			"name": "promisesDNS",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"promisesFS": {
-		"eslint": [
-			{
-				"name": "n/prefer-promises/fs",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-promises.md"
-			}
-		],
-		"flint": {
-			"name": "promisesFS",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"propertyAccessNotation": {
+	{
 		"biome": [
 			{
 				"name": "useLiteralKeys",
@@ -11957,30 +10834,11 @@
 		],
 		"flint": {
 			"name": "propertyAccessNotation",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"propertyOrdering": {
-		"eslint": [
-			{
-				"name": "package-json/order-properties",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/order-properties.md"
-			}
-		],
-		"flint": {
-			"name": "propertyOrdering",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"prototypeIterators": {
+	{
 		"eslint": [
 			{
 				"name": "no-iterator",
@@ -11989,10 +10847,7 @@
 		],
 		"flint": {
 			"name": "prototypeIterators",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -12002,23 +10857,7 @@
 			}
 		]
 	},
-	"publishConfigValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-publishConfig",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-publishConfig.md"
-			}
-		],
-		"flint": {
-			"name": "publishConfigValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"readonlyClassProperties": {
+	{
 		"biome": [
 			{
 				"name": "useReadonlyClassProperties",
@@ -12033,21 +10872,15 @@
 		],
 		"flint": {
 			"name": "readonlyClassProperties",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing",
 			"strictness": "Strict"
 		}
 	},
-	"recursionOnlyArguments": {
+	{
 		"flint": {
 			"name": "recursionOnlyArguments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -12057,7 +10890,7 @@
 			}
 		]
 	},
-	"reduceTypeParameters": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/prefer-reduce-type-parameter",
@@ -12066,10 +10899,7 @@
 		],
 		"flint": {
 			"name": "reduceTypeParameters",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		},
@@ -12080,7 +10910,7 @@
 			}
 		]
 	},
-	"redundantTypeConstituents": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-redundant-type-constituents",
@@ -12089,10 +10919,7 @@
 		],
 		"flint": {
 			"name": "redundantTypeConstituents",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -12102,23 +10929,7 @@
 			}
 		]
 	},
-	"referenceLikeUrls": {
-		"eslint": [
-			{
-				"name": "markdown/no-reference-like-url",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-reference-like-url.md"
-			}
-		],
-		"flint": {
-			"name": "referenceLikeUrls",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Logical"
-		}
-	},
-	"reflectApplies": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-reflect-apply",
@@ -12127,10 +10938,7 @@
 		],
 		"flint": {
 			"name": "reflectApplies",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -12140,7 +10948,7 @@
 			}
 		]
 	},
-	"regexAllGlobalFlags": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-missing-g-flag",
@@ -12149,10 +10957,7 @@
 		],
 		"flint": {
 			"name": "regexAllGlobalFlags",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -12162,7 +10967,7 @@
 			}
 		]
 	},
-	"regexAmbiguousInvalidity": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/strict",
@@ -12171,14 +10976,11 @@
 		],
 		"flint": {
 			"name": "regexAmbiguousInvalidity",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexCharacterClasses": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/prefer-character-class",
@@ -12187,15 +10989,12 @@
 		],
 		"flint": {
 			"name": "regexCharacterClasses",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"regexCharacterClassRanges": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/prefer-range",
@@ -12204,14 +11003,11 @@
 		],
 		"flint": {
 			"name": "regexCharacterClassRanges",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"regexCharacterClassSetOperations": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/prefer-set-operation",
@@ -12220,14 +11016,11 @@
 		],
 		"flint": {
 			"name": "regexCharacterClassSetOperations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"regexConciseCharacterClassNegations": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/negation",
@@ -12236,14 +11029,11 @@
 		],
 		"flint": {
 			"name": "regexConciseCharacterClassNegations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"regexConciseness": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/better-regex",
@@ -12252,15 +11042,12 @@
 		],
 		"flint": {
 			"name": "regexConciseness",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Superseded by other regex cleanliness rules"
 	},
-	"regexConsecutiveSpaces": {
+	{
 		"biome": [
 			{
 				"name": "noAdjacentSpacesInRegex",
@@ -12281,10 +11068,7 @@
 		],
 		"flint": {
 			"name": "regexConsecutiveSpaces",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -12294,7 +11078,7 @@
 			}
 		]
 	},
-	"regexContradictoryAssertions": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-contradiction-with-assertion",
@@ -12303,14 +11087,11 @@
 		],
 		"flint": {
 			"name": "regexContradictoryAssertions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexControlCharacterEscapes": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/control-character-escape",
@@ -12319,14 +11100,11 @@
 		],
 		"flint": {
 			"name": "regexControlCharacterEscapes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexControlCharacters": {
+	{
 		"biome": [
 			{
 				"name": "noControlCharactersInRegex",
@@ -12351,10 +11129,7 @@
 		],
 		"flint": {
 			"name": "regexControlCharacters",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -12364,7 +11139,7 @@
 			}
 		]
 	},
-	"regexDigitMatchers": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/prefer-d",
@@ -12373,15 +11148,12 @@
 		],
 		"flint": {
 			"name": "regexDigitMatchers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"regexDivisionStarts": {
+	{
 		"eslint": [
 			{
 				"name": "no-div-regex",
@@ -12390,10 +11162,7 @@
 		],
 		"flint": {
 			"name": "regexDivisionStarts",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -12403,7 +11172,7 @@
 			}
 		]
 	},
-	"regexDollarEscapes": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/prefer-escape-replacement-dollar-char",
@@ -12412,14 +11181,11 @@
 		],
 		"flint": {
 			"name": "regexDollarEscapes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"regexDuplicateCharacterClassCharacters": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-dupe-characters-character-class",
@@ -12428,14 +11194,11 @@
 		],
 		"flint": {
 			"name": "regexDuplicateCharacterClassCharacters",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexDuplicateDisjunctions": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-dupe-disjunctions",
@@ -12444,14 +11207,11 @@
 		],
 		"flint": {
 			"name": "regexDuplicateDisjunctions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexEmptyAlternatives": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-empty-alternative",
@@ -12460,14 +11220,11 @@
 		],
 		"flint": {
 			"name": "regexEmptyAlternatives",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexEmptyCapturingGroups": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-empty-capturing-group",
@@ -12476,14 +11233,11 @@
 		],
 		"flint": {
 			"name": "regexEmptyCapturingGroups",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexEmptyCharacterClasses": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-empty-character-class",
@@ -12492,14 +11246,11 @@
 		],
 		"flint": {
 			"name": "regexEmptyCharacterClasses",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexEmptyGroups": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-empty-group",
@@ -12508,14 +11259,11 @@
 		],
 		"flint": {
 			"name": "regexEmptyGroups",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexEmptyLazyQuantifiers": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-lazy-ends",
@@ -12524,14 +11272,11 @@
 		],
 		"flint": {
 			"name": "regexEmptyLazyQuantifiers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexEmptyLookaroundsAssertions": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-empty-lookarounds-assertion",
@@ -12540,14 +11285,11 @@
 		],
 		"flint": {
 			"name": "regexEmptyLookaroundsAssertions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexEmptyStringLiterals": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-empty-string-literal",
@@ -12556,14 +11298,11 @@
 		],
 		"flint": {
 			"name": "regexEmptyStringLiterals",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexEscapeBackspaces": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-escape-backspace",
@@ -12572,14 +11311,11 @@
 		],
 		"flint": {
 			"name": "regexEscapeBackspaces",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexExecutors": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/prefer-regexp-exec",
@@ -12592,31 +11328,12 @@
 		],
 		"flint": {
 			"name": "regexExecutors",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "strict"
 		}
 	},
-	"regexFlags": {
-		"eslint": [
-			{
-				"name": "regexp/sort-flags",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/sort-flags.html"
-			}
-		],
-		"flint": {
-			"name": "regexFlags",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"regexGraphemeStringLiterals": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/grapheme-string-literal",
@@ -12625,15 +11342,12 @@
 		],
 		"flint": {
 			"name": "regexGraphemeStringLiterals",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		}
 	},
-	"regexHexadecimalEscapes": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/hexadecimal-escape",
@@ -12642,15 +11356,12 @@
 		],
 		"flint": {
 			"name": "regexHexadecimalEscapes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"regexIgnoreCaseFlags": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/use-ignore-case",
@@ -12659,14 +11370,11 @@
 		],
 		"flint": {
 			"name": "regexIgnoreCaseFlags",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexInvisibleCharacters": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-invisible-character",
@@ -12675,14 +11383,11 @@
 		],
 		"flint": {
 			"name": "regexInvisibleCharacters",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexLegacyFeatures": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-legacy-features",
@@ -12691,14 +11396,11 @@
 		],
 		"flint": {
 			"name": "regexLegacyFeatures",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexLetterCasing": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/letter-case",
@@ -12707,31 +11409,12 @@
 		],
 		"flint": {
 			"name": "regexLetterCasing",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"regexLists": {
-		"eslint": [
-			{
-				"name": "regexp/sort-alternatives",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/sort-alternatives.html"
-			}
-		],
-		"flint": {
-			"name": "regexLists",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"regexLiterals": {
+	{
 		"biome": [
 			{
 				"name": "useRegexLiterals",
@@ -12746,14 +11429,11 @@
 		],
 		"flint": {
 			"name": "regexLiterals",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexLookaroundAssertions": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/prefer-lookaround",
@@ -12762,15 +11442,12 @@
 		],
 		"flint": {
 			"name": "regexLookaroundAssertions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"regexLookaroundQuantifierOptimizations": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/optimal-lookaround-quantifier",
@@ -12779,14 +11456,11 @@
 		],
 		"flint": {
 			"name": "regexLookaroundQuantifierOptimizations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexMatchNotation": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/match-any",
@@ -12795,15 +11469,12 @@
 		],
 		"flint": {
 			"name": "regexMatchNotation",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"regexMisleadingCapturingGroups": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-misleading-capturing-group",
@@ -12812,14 +11483,11 @@
 		],
 		"flint": {
 			"name": "regexMisleadingCapturingGroups",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexMisleadingQuantifiers": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/confusing-quantifier",
@@ -12828,14 +11496,11 @@
 		],
 		"flint": {
 			"name": "regexMisleadingQuantifiers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexMisleadingUnicodeCharacters": {
+	{
 		"biome": [
 			{
 				"name": "noMisleadingCharacterClass",
@@ -12854,14 +11519,11 @@
 		],
 		"flint": {
 			"name": "regexMisleadingUnicodeCharacters",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexNamedBackreferences": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/prefer-named-backreference",
@@ -12870,15 +11532,12 @@
 		],
 		"flint": {
 			"name": "regexNamedBackreferences",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"regexNamedCaptureGroups": {
+	{
 		"eslint": [
 			{
 				"name": "prefer-named-capture-group",
@@ -12891,14 +11550,11 @@
 		],
 		"flint": {
 			"name": "regexNamedCaptureGroups",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexNamedReplacements": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/prefer-named-replacement",
@@ -12907,15 +11563,12 @@
 		],
 		"flint": {
 			"name": "regexNamedReplacements",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"regexNonStandardFlags": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-non-standard-flag",
@@ -12924,14 +11577,11 @@
 		],
 		"flint": {
 			"name": "regexNonStandardFlags",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexObscureRanges": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-obscure-range",
@@ -12940,14 +11590,11 @@
 		],
 		"flint": {
 			"name": "regexObscureRanges",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexOctalEscapes": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-octal",
@@ -12956,14 +11603,11 @@
 		],
 		"flint": {
 			"name": "regexOctalEscapes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexPlusQuantifiers": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/prefer-plus-quantifier",
@@ -12972,15 +11616,12 @@
 		],
 		"flint": {
 			"name": "regexPlusQuantifiers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"regexPredefinedAssertions": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/prefer-predefined-assertion",
@@ -12989,14 +11630,11 @@
 		],
 		"flint": {
 			"name": "regexPredefinedAssertions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"regexQuantifierOptimizations": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/optimal-quantifier-concatenation",
@@ -13005,14 +11643,11 @@
 		],
 		"flint": {
 			"name": "regexQuantifierOptimizations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexQuestionQuantifiers": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/prefer-question-quantifier",
@@ -13021,15 +11656,12 @@
 		],
 		"flint": {
 			"name": "regexQuestionQuantifiers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"regexRepeatQuantifiers": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/prefer-quantifier",
@@ -13038,14 +11670,11 @@
 		],
 		"flint": {
 			"name": "regexRepeatQuantifiers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"regexResultArrayGroups": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/prefer-result-array-groups",
@@ -13054,15 +11683,12 @@
 		],
 		"flint": {
 			"name": "regexResultArrayGroups",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"regexSetOperationOptimizations": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/simplify-set-operations",
@@ -13071,14 +11697,11 @@
 		],
 		"flint": {
 			"name": "regexSetOperationOptimizations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexStandaloneBackslashes": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-standalone-backslash",
@@ -13087,14 +11710,11 @@
 		],
 		"flint": {
 			"name": "regexStandaloneBackslashes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexStarQuantifiers": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/prefer-star-quantifier",
@@ -13103,15 +11723,12 @@
 		],
 		"flint": {
 			"name": "regexStarQuantifiers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"regexSuperLinearBacktracking": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-super-linear-backtracking",
@@ -13120,14 +11737,11 @@
 		],
 		"flint": {
 			"name": "regexSuperLinearBacktracking",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexSuperLinearMoves": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-super-linear-move",
@@ -13136,14 +11750,11 @@
 		],
 		"flint": {
 			"name": "regexSuperLinearMoves",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexTestMethods": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/prefer-regexp-test",
@@ -13156,10 +11767,7 @@
 		],
 		"flint": {
 			"name": "regexTestMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -13169,7 +11777,7 @@
 			}
 		]
 	},
-	"regexTopLevelDeclarations": {
+	{
 		"biome": [
 			{
 				"name": "useTopLevelRegex",
@@ -13178,14 +11786,11 @@
 		],
 		"flint": {
 			"name": "regexTopLevelDeclarations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"regexUnicodeCodepointEscapes": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/prefer-unicode-codepoint-escapes",
@@ -13194,15 +11799,12 @@
 		],
 		"flint": {
 			"name": "regexUnicodeCodepointEscapes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"regexUnicodeEscapes": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/unicode-escape",
@@ -13211,14 +11813,11 @@
 		],
 		"flint": {
 			"name": "regexUnicodeEscapes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"regexUnicodeFlag": {
+	{
 		"eslint": [
 			{
 				"name": "require-unicode-regexp",
@@ -13231,14 +11830,11 @@
 		],
 		"flint": {
 			"name": "regexUnicodeFlag",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "None"
 		}
 	},
-	"regexUnicodeProperties": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/unicode-property",
@@ -13247,14 +11843,11 @@
 		],
 		"flint": {
 			"name": "regexUnicodeProperties",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"regexUnicodeSetsFlag": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/require-unicode-sets-regexp",
@@ -13263,14 +11856,11 @@
 		],
 		"flint": {
 			"name": "regexUnicodeSetsFlag",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"regexUnnecessaryAssertions": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-useless-assertions",
@@ -13279,14 +11869,11 @@
 		],
 		"flint": {
 			"name": "regexUnnecessaryAssertions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexUnnecessaryBackreferences": {
+	{
 		"biome": [
 			{
 				"name": "noUselessRegexBackrefs",
@@ -13305,10 +11892,7 @@
 		],
 		"flint": {
 			"name": "regexUnnecessaryBackreferences",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -13318,7 +11902,7 @@
 			}
 		]
 	},
-	"regexUnnecessaryCharacterClasses": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-useless-character-class",
@@ -13327,14 +11911,11 @@
 		],
 		"flint": {
 			"name": "regexUnnecessaryCharacterClasses",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexUnnecessaryCharacterRanges": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-useless-range",
@@ -13343,14 +11924,11 @@
 		],
 		"flint": {
 			"name": "regexUnnecessaryCharacterRanges",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexUnnecessaryDisjunctions": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-useless-string-literal",
@@ -13359,14 +11937,11 @@
 		],
 		"flint": {
 			"name": "regexUnnecessaryDisjunctions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexUnnecessaryDollarReplacements": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-useless-dollar-replacements",
@@ -13375,14 +11950,11 @@
 		],
 		"flint": {
 			"name": "regexUnnecessaryDollarReplacements",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexUnnecessaryEscapes": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-useless-escape",
@@ -13391,10 +11963,7 @@
 		],
 		"flint": {
 			"name": "regexUnnecessaryEscapes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -13404,7 +11973,7 @@
 			}
 		]
 	},
-	"regexUnnecessaryLookaroundAssertions": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-extra-lookaround-assertions",
@@ -13413,14 +11982,11 @@
 		],
 		"flint": {
 			"name": "regexUnnecessaryLookaroundAssertions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexUnnecessaryNestedAssertions": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-trivially-nested-assertion",
@@ -13429,14 +11995,11 @@
 		],
 		"flint": {
 			"name": "regexUnnecessaryNestedAssertions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexUnnecessaryNestedQuantifiers": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-trivially-nested-quantifier",
@@ -13445,14 +12008,11 @@
 		],
 		"flint": {
 			"name": "regexUnnecessaryNestedQuantifiers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexUnnecessaryNonCapturingGroups": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-useless-non-capturing-group",
@@ -13461,15 +12021,12 @@
 		],
 		"flint": {
 			"name": "regexUnnecessaryNonCapturingGroups",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"regexUnnecessaryNumericQuantifiers": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-useless-two-nums-quantifier",
@@ -13478,14 +12035,11 @@
 		],
 		"flint": {
 			"name": "regexUnnecessaryNumericQuantifiers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexUnnecessaryOptionalAssertions": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-optional-assertion",
@@ -13494,14 +12048,11 @@
 		],
 		"flint": {
 			"name": "regexUnnecessaryOptionalAssertions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexUnnecessaryReferentialBackreferences": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-potentially-useless-backreference",
@@ -13510,14 +12061,11 @@
 		],
 		"flint": {
 			"name": "regexUnnecessaryReferentialBackreferences",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexUnnecessarySetOperands": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-useless-set-operand",
@@ -13526,14 +12074,11 @@
 		],
 		"flint": {
 			"name": "regexUnnecessarySetOperands",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexUnusedCapturingGroups": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-unused-capturing-group",
@@ -13542,14 +12087,11 @@
 		],
 		"flint": {
 			"name": "regexUnusedCapturingGroups",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexUnusedFlags": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-useless-flag",
@@ -13558,14 +12100,11 @@
 		],
 		"flint": {
 			"name": "regexUnusedFlags",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexUnusedLazyQuantifiers": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-useless-lazy",
@@ -13574,14 +12113,11 @@
 		],
 		"flint": {
 			"name": "regexUnusedLazyQuantifiers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexUnusedQuantifiers": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-useless-quantifier",
@@ -13590,14 +12126,11 @@
 		],
 		"flint": {
 			"name": "regexUnusedQuantifiers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"regexValidity": {
+	{
 		"deno": [
 			{
 				"name": "no-invalid-regexp",
@@ -13616,10 +12149,7 @@
 		],
 		"flint": {
 			"name": "regexValidity",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -13629,7 +12159,7 @@
 			}
 		]
 	},
-	"regexWordMatchers": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/prefer-w",
@@ -13638,15 +12168,12 @@
 		],
 		"flint": {
 			"name": "regexWordMatchers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"regexZeroQuantifiers": {
+	{
 		"eslint": [
 			{
 				"name": "regexp/no-zero-quantifier",
@@ -13655,84 +12182,11 @@
 		],
 		"flint": {
 			"name": "regexZeroQuantifiers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"removeEventListenerExpressions": {
-		"eslint": [
-			{
-				"name": "unicorn/no-invalid-remove-event-listener",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-invalid-remove-event-listener.md"
-			}
-		],
-		"flint": {
-			"name": "removeEventListenerExpressions",
-			"plugin": {
-				"code": "browser",
-				"name": "Browser"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/no-invalid-remove-event-listener",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-invalid-remove-event-listener.html"
-			}
-		]
-	},
-	"repositoryDirectoryValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-repository-directory",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-repository-directory.md"
-			}
-		],
-		"flint": {
-			"name": "repositoryDirectoryValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"repositoryShorthand": {
-		"eslint": [
-			{
-				"name": "package-json/repository-shorthand",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/repository-shorthand.md"
-			}
-		],
-		"flint": {
-			"name": "repositoryShorthand",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"repositoryValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-repository",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-repository.md"
-			}
-		],
-		"flint": {
-			"name": "repositoryValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"requireImports": {
+	{
 		"biome": [
 			{
 				"name": "noCommonJs",
@@ -13747,10 +12201,7 @@
 		],
 		"flint": {
 			"name": "requireImports",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -13760,7 +12211,7 @@
 			}
 		]
 	},
-	"responseMethods": {
+	{
 		"biome": [
 			{
 				"name": "useStaticResponseMethods",
@@ -13769,14 +12220,11 @@
 		],
 		"flint": {
 			"name": "responseMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"restrictedDirectives": {
+	{
 		"eslint": [
 			{
 				"name": "@eslint-community/eslint-comments/no-use",
@@ -13785,14 +12233,11 @@
 		],
 		"flint": {
 			"name": "restrictedDirectives",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"restrictedExports": {
+	{
 		"eslint": [
 			{
 				"name": "no-restricted-exports",
@@ -13801,14 +12246,11 @@
 		],
 		"flint": {
 			"name": "restrictedExports",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"restrictedGlobals": {
+	{
 		"biome": [
 			{
 				"name": "noRestrictedGlobals",
@@ -13823,10 +12265,7 @@
 		],
 		"flint": {
 			"name": "restrictedGlobals",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "None"
 		},
 		"oxlint": [
@@ -13836,7 +12275,7 @@
 			}
 		]
 	},
-	"restrictedIdentifiers": {
+	{
 		"eslint": [
 			{
 				"name": "id-denylist",
@@ -13845,14 +12284,11 @@
 		],
 		"flint": {
 			"name": "restrictedIdentifiers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "None"
 		}
 	},
-	"restrictedImports": {
+	{
 		"biome": [
 			{
 				"name": "noRestrictedImports",
@@ -13871,10 +12307,7 @@
 		],
 		"flint": {
 			"name": "restrictedImports",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "None"
 		},
 		"oxlint": [
@@ -13884,7 +12317,7 @@
 			}
 		]
 	},
-	"restrictedJSDocs": {
+	{
 		"eslint": [
 			{
 				"name": "jsdoc/no-restricted-syntax",
@@ -13893,14 +12326,11 @@
 		],
 		"flint": {
 			"name": "restrictedJSDocs",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"restrictedProperties": {
+	{
 		"eslint": [
 			{
 				"name": "no-restricted-properties",
@@ -13909,30 +12339,11 @@
 		],
 		"flint": {
 			"name": "restrictedProperties",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "None"
 		}
 	},
-	"restrictedRequires": {
-		"eslint": [
-			{
-				"name": "n/no-restricted-require",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-restricted-require.md"
-			}
-		],
-		"flint": {
-			"name": "restrictedRequires",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"restrictedSyntax": {
+	{
 		"eslint": [
 			{
 				"name": "no-restricted-syntax",
@@ -13941,14 +12352,11 @@
 		],
 		"flint": {
 			"name": "restrictedSyntax",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "None"
 		}
 	},
-	"restrictedTypes": {
+	{
 		"biome": [
 			{
 				"name": "noBannedTypes",
@@ -13963,20 +12371,14 @@
 		],
 		"flint": {
 			"name": "restrictedTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "None"
 		}
 	},
-	"restSpreadProperties": {
+	{
 		"flint": {
 			"name": "restSpreadProperties",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -13986,7 +12388,7 @@
 			}
 		]
 	},
-	"returnAssignments": {
+	{
 		"eslint": [
 			{
 				"name": "no-return-assign",
@@ -13995,10 +12397,7 @@
 		],
 		"flint": {
 			"name": "returnAssignments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -14008,7 +12407,7 @@
 			}
 		]
 	},
-	"returnAwaitPromises": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/return-await",
@@ -14017,10 +12416,7 @@
 		],
 		"flint": {
 			"name": "returnAwaitPromises",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -14030,7 +12426,7 @@
 			}
 		]
 	},
-	"returnThisTypes": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/prefer-return-this-type",
@@ -14039,10 +12435,7 @@
 		],
 		"flint": {
 			"name": "returnThisTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		},
@@ -14053,156 +12446,7 @@
 			}
 		]
 	},
-	"roleRedundancies": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/no-redundant-roles",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-redundant-roles.md"
-			}
-		],
-		"flint": {
-			"name": "roleRedundancies",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/no-redundant-roles",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/no-redundant-roles.html"
-			}
-		]
-	},
-	"roleRequiredAriaProps": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/role-has-required-aria-props",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/role-has-required-aria-props.md"
-			}
-		],
-		"flint": {
-			"name": "roleRequiredAriaProps",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/role-has-required-aria-props",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/role-has-required-aria-props.html"
-			}
-		]
-	},
-	"roleTags": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/prefer-tag-over-role",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/prefer-tag-over-role.md"
-			}
-		],
-		"flint": {
-			"name": "roleTags",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical",
-			"strictness": "Strict"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/prefer-tag-over-role",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/prefer-tag-over-role.html"
-			}
-		]
-	},
-	"ruleSupportedAriaProps": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/role-supports-aria-props",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/role-supports-aria-props.md"
-			}
-		],
-		"flint": {
-			"name": "ruleSupportedAriaProps",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/role-supports-aria-props",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/role-supports-aria-props.html"
-			}
-		]
-	},
-	"scopeProps": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/scope",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/scope.md"
-			}
-		],
-		"flint": {
-			"name": "scopeProps",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/scope",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/scope.html"
-			}
-		]
-	},
-	"scriptsValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-scripts",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-scripts.md"
-			}
-		],
-		"flint": {
-			"name": "scriptsValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"scriptUrls": {
-		"eslint": [
-			{
-				"name": "no-script-url",
-				"url": "https://eslint.org/docs/latest/rules/no-script-url"
-			}
-		],
-		"flint": {
-			"name": "scriptUrls",
-			"plugin": {
-				"code": "browser",
-				"name": "Browser"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "eslint/no-script-url",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-script-url.html"
-			}
-		]
-	},
-	"selfAssignments": {
+	{
 		"biome": [
 			{
 				"name": "noSelfAssign",
@@ -14223,10 +12467,7 @@
 		],
 		"flint": {
 			"name": "selfAssignments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -14236,7 +12477,7 @@
 			}
 		]
 	},
-	"selfComparisons": {
+	{
 		"biome": [
 			{
 				"name": "noSelfCompare",
@@ -14257,10 +12498,7 @@
 		],
 		"flint": {
 			"name": "selfComparisons",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		},
@@ -14272,7 +12510,7 @@
 			}
 		]
 	},
-	"sequences": {
+	{
 		"biome": [
 			{
 				"name": "noCommaOperator",
@@ -14287,14 +12525,11 @@
 		],
 		"flint": {
 			"name": "sequences",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		}
 	},
-	"setHasExistenceChecks": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-set-has",
@@ -14303,10 +12538,7 @@
 		],
 		"flint": {
 			"name": "setHasExistenceChecks",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -14317,23 +12549,7 @@
 			}
 		]
 	},
-	"sets": {
-		"eslint": [
-			{
-				"name": "perfectionist/sort-sets",
-				"url": "https://perfectionist.dev/rules/sort-sets"
-			}
-		],
-		"flint": {
-			"name": "sets",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"setSizeLengthChecks": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-set-size",
@@ -14342,10 +12558,7 @@
 		],
 		"flint": {
 			"name": "setSizeLengthChecks",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -14356,7 +12569,7 @@
 			}
 		]
 	},
-	"setterReturns": {
+	{
 		"biome": [
 			{
 				"name": "noSetterReturn",
@@ -14377,10 +12590,7 @@
 		],
 		"flint": {
 			"name": "setterReturns",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -14390,7 +12600,7 @@
 			}
 		]
 	},
-	"shadowedRestrictedNames": {
+	{
 		"biome": [
 			{
 				"name": "noShadowRestrictedNames",
@@ -14411,10 +12621,7 @@
 		],
 		"flint": {
 			"name": "shadowedRestrictedNames",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -14424,12 +12631,9 @@
 			}
 		]
 	},
-	"shadows": {
+	{
 		"biome": [
-			{
-				"name": "noShadow",
-				"url": "https://biomejs.dev/linter/rules/noShadow"
-			}
+			{ "name": "noShadow", "url": "https://biomejs.dev/linter/rules/noShadow" }
 		],
 		"eslint": [
 			{
@@ -14443,14 +12647,11 @@
 		],
 		"flint": {
 			"name": "shadows",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"shoutyConstants": {
+	{
 		"biome": [
 			{
 				"name": "noShoutyConstants",
@@ -14459,14 +12660,11 @@
 		],
 		"flint": {
 			"name": "shoutyConstants",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"singleVariableDeclarations": {
+	{
 		"biome": [
 			{
 				"name": "useSingleVarDeclarator",
@@ -14487,14 +12685,11 @@
 		],
 		"flint": {
 			"name": "singleVariableDeclarations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"sizeComparisonOperators": {
+	{
 		"biome": [
 			{
 				"name": "useExplicitLengthCheck",
@@ -14509,10 +12704,7 @@
 		],
 		"flint": {
 			"name": "sizeComparisonOperators",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -14523,7 +12715,7 @@
 			}
 		]
 	},
-	"slowTypes": {
+	{
 		"deno": [
 			{
 				"name": "no-slow-types",
@@ -14532,14 +12724,11 @@
 		],
 		"flint": {
 			"name": "slowTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"sparseArrays": {
+	{
 		"biome": [
 			{
 				"name": "noSparseArray",
@@ -14560,10 +12749,7 @@
 		],
 		"flint": {
 			"name": "sparseArrays",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -14573,45 +12759,7 @@
 			}
 		]
 	},
-	"spreadAccumulators": {
-		"biome": [
-			{
-				"name": "noAccumulatingSpread",
-				"url": "https://biomejs.dev/linter/rules/noAccumulatingSpread"
-			}
-		],
-		"flint": {
-			"name": "spreadAccumulators",
-			"plugin": {
-				"code": "performance",
-				"name": "Performance"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "oxc/no-accumulating-spread",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/oxc/no-accumulating-spread.html"
-			}
-		]
-	},
-	"staticElementInteractions": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/no-static-element-interactions",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-static-element-interactions.md"
-			}
-		],
-		"flint": {
-			"name": "staticElementInteractions",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		}
-	},
-	"staticMemberOnlyClasses": {
+	{
 		"biome": [
 			{
 				"name": "noStaticOnlyClass",
@@ -14626,10 +12774,7 @@
 		],
 		"flint": {
 			"name": "staticMemberOnlyClasses",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -14640,7 +12785,7 @@
 			}
 		]
 	},
-	"strictMode": {
+	{
 		"biome": [
 			{
 				"name": "useStrictMode",
@@ -14649,14 +12794,11 @@
 		],
 		"flint": {
 			"name": "strictMode",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"stringCaseMismatches": {
+	{
 		"biome": [
 			{
 				"name": "noStringCaseMismatch",
@@ -14665,14 +12807,11 @@
 		],
 		"flint": {
 			"name": "stringCaseMismatches",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"stringCodePoints": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-code-point",
@@ -14681,10 +12820,7 @@
 		],
 		"flint": {
 			"name": "stringCodePoints",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		},
@@ -14695,7 +12831,7 @@
 			}
 		]
 	},
-	"stringConcatenationTemplates": {
+	{
 		"biome": [
 			{
 				"name": "useTemplate",
@@ -14710,10 +12846,7 @@
 		],
 		"flint": {
 			"name": "stringConcatenationTemplates",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -14723,7 +12856,7 @@
 			}
 		]
 	},
-	"stringContents": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/string-content",
@@ -14732,31 +12865,11 @@
 		],
 		"flint": {
 			"name": "stringContents",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"stringMappingKeys": {
-		"eslint": [
-			{
-				"name": "yml/require-string-key",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/require-string-key.html"
-			}
-		],
-		"flint": {
-			"name": "stringMappingKeys",
-			"plugin": {
-				"code": "yml",
-				"name": "YML"
-			},
-			"preset": "Logical",
-			"strictness": "Strict"
-		}
-	},
-	"stringRawEscapes": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-string-raw",
@@ -14765,10 +12878,7 @@
 		],
 		"flint": {
 			"name": "stringRawEscapes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -14778,7 +12888,7 @@
 			}
 		]
 	},
-	"stringReplaceAllRegexSearches": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-string-replace-all",
@@ -14787,10 +12897,7 @@
 		],
 		"flint": {
 			"name": "stringReplaceAllRegexSearches",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -14800,12 +12907,9 @@
 			}
 		]
 	},
-	"stringSliceMethods": {
+	{
 		"biome": [
-			{
-				"name": "noSubstr",
-				"url": "https://biomejs.dev/linter/rules/noSubstr"
-			}
+			{ "name": "noSubstr", "url": "https://biomejs.dev/linter/rules/noSubstr" }
 		],
 		"eslint": [
 			{
@@ -14815,10 +12919,7 @@
 		],
 		"flint": {
 			"name": "stringSliceMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -14829,7 +12930,7 @@
 			}
 		]
 	},
-	"stringStartsEndsWith": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/prefer-string-starts-ends-with",
@@ -14838,10 +12939,7 @@
 		],
 		"flint": {
 			"name": "stringStartsEndsWith",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -14851,7 +12949,7 @@
 			}
 		]
 	},
-	"stringStartsEndsWithMethods": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-string-starts-ends-with",
@@ -14860,14 +12958,11 @@
 		],
 		"flint": {
 			"name": "stringStartsEndsWithMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"stringTemplateCurlies": {
+	{
 		"biome": [
 			{
 				"name": "noTemplateCurlyInString",
@@ -14882,10 +12977,7 @@
 		],
 		"flint": {
 			"name": "stringTemplateCurlies",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -14895,7 +12987,7 @@
 			}
 		]
 	},
-	"stringTrimMethods": {
+	{
 		"biome": [
 			{
 				"name": "useTrimStartEnd",
@@ -14910,10 +13002,7 @@
 		],
 		"flint": {
 			"name": "stringTrimMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -14924,7 +13013,7 @@
 			}
 		]
 	},
-	"structuredCloneMethods": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-structured-clone",
@@ -14933,10 +13022,7 @@
 		],
 		"flint": {
 			"name": "structuredCloneMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -14947,23 +13033,7 @@
 			}
 		]
 	},
-	"svgTitles": {
-		"biome": [
-			{
-				"name": "noSvgWithoutTitle",
-				"url": "https://biomejs.dev/linter/rules/noSvgWithoutTitle"
-			}
-		],
-		"flint": {
-			"name": "svgTitles",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		}
-	},
-	"switchCaseBraces": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/switch-case-braces",
@@ -14972,10 +13042,7 @@
 		],
 		"flint": {
 			"name": "switchCaseBraces",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -14985,23 +13052,7 @@
 			}
 		]
 	},
-	"switchCases": {
-		"eslint": [
-			{
-				"name": "perfectionist/sort-switch-case",
-				"url": "https://perfectionist.dev/rules/sort-switch-case"
-			}
-		],
-		"flint": {
-			"name": "switchCases",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"switchExhaustiveness": {
+	{
 		"biome": [
 			{
 				"name": "useExhaustiveSwitchCases",
@@ -15016,10 +13067,7 @@
 		],
 		"flint": {
 			"name": "switchExhaustiveness",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -15029,7 +13077,7 @@
 			}
 		]
 	},
-	"symbolDescriptions": {
+	{
 		"biome": [
 			{
 				"name": "useSymbolDescription",
@@ -15044,10 +13092,7 @@
 		],
 		"flint": {
 			"name": "symbolDescriptions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -15057,7 +13102,7 @@
 			}
 		]
 	},
-	"syncFunctionAwaits": {
+	{
 		"deno": [
 			{
 				"name": "no-await-in-sync-fun",
@@ -15066,85 +13111,12 @@
 		],
 		"flint": {
 			"name": "syncFunctionAwaits",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Generally handled by parsers."
 	},
-	"syncFunctionInAsyncFunctions": {
-		"deno": [
-			{
-				"name": "no-sync-fn-in-async-fn",
-				"url": "https://docs.deno.com/lint/rules/no-sync-fn-in-async-fn"
-			}
-		],
-		"flint": {
-			"name": "syncFunctionInAsyncFunctions",
-			"plugin": {
-				"code": "deno",
-				"name": "Deno"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"synchronousMethods": {
-		"eslint": [
-			{
-				"name": "n/no-sync",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-sync.md"
-			}
-		],
-		"flint": {
-			"name": "synchronousMethods",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"tabIndexPositiveValues": {
-		"eslint": [
-			{
-				"name": "jsx-a11y/tabindex-no-positive",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/tabindex-no-positive.md"
-			}
-		],
-		"flint": {
-			"name": "tabIndexPositiveValues",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical"
-		},
-		"oxlint": [
-			{
-				"name": "jsx_a11y/tabindex-no-positive",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/tabindex-no-positive.html"
-			}
-		]
-	},
-	"tableColumnCounts": {
-		"eslint": [
-			{
-				"name": "markdown/table-column-count",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/table-column-count.md"
-			}
-		],
-		"flint": {
-			"name": "tableColumnCounts",
-			"plugin": {
-				"code": "md",
-				"name": "Markdown"
-			},
-			"preset": "Logical"
-		}
-	},
-	"templateExpressionValues": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/restrict-template-expressions",
@@ -15153,10 +13125,7 @@
 		],
 		"flint": {
 			"name": "templateExpressionValues",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -15166,7 +13135,7 @@
 			}
 		]
 	},
-	"templateIndents": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/template-indent",
@@ -15175,31 +13144,11 @@
 		],
 		"flint": {
 			"name": "templateIndents",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"templateLiterals": {
-		"eslint": [
-			{
-				"name": "jsonc/no-template-literals",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-template-literals.html"
-			}
-		],
-		"flint": {
-			"name": "templateLiterals",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"ternaryNesting": {
+	{
 		"biome": [
 			{
 				"name": "noNestedTernary",
@@ -15218,10 +13167,7 @@
 		],
 		"flint": {
 			"name": "ternaryNesting",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -15235,7 +13181,7 @@
 			}
 		]
 	},
-	"ternaryOperators": {
+	{
 		"eslint": [
 			{
 				"name": "no-ternary",
@@ -15244,10 +13190,7 @@
 		],
 		"flint": {
 			"name": "ternaryOperators",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -15257,7 +13200,7 @@
 			}
 		]
 	},
-	"textEncodingCases": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/text-encoding-identifier-case",
@@ -15266,10 +13209,7 @@
 		],
 		"flint": {
 			"name": "textEncodingCases",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -15279,7 +13219,7 @@
 			}
 		]
 	},
-	"thisAliases": {
+	{
 		"eslint": [
 			{
 				"name": "consistent-this",
@@ -15288,14 +13228,11 @@
 		],
 		"flint": {
 			"name": "thisAliases",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"thisBeforeSuper": {
+	{
 		"biome": [
 			{
 				"name": "noUnreachableSuper",
@@ -15316,10 +13253,7 @@
 		],
 		"flint": {
 			"name": "thisBeforeSuper",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -15329,7 +13263,7 @@
 			}
 		]
 	},
-	"thisInStatic": {
+	{
 		"biome": [
 			{
 				"name": "noThisInStatic",
@@ -15338,14 +13272,11 @@
 		],
 		"flint": {
 			"name": "thisInStatic",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"throwErrors": {
+	{
 		"biome": [
 			{
 				"name": "useThrowOnlyError",
@@ -15374,10 +13305,7 @@
 		],
 		"flint": {
 			"name": "throwErrors",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -15395,7 +13323,7 @@
 			}
 		]
 	},
-	"todoExpirations": {
+	{
 		"deno": [
 			{
 				"name": "ban-untagged-todo",
@@ -15410,14 +13338,11 @@
 		],
 		"flint": {
 			"name": "todoExpirations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"topLevelAwaits": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-top-level-await",
@@ -15426,48 +13351,12 @@
 		],
 		"flint": {
 			"name": "topLevelAwaits",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		}
 	},
-	"topLevelInteroperability": {
-		"eslint": [
-			{
-				"name": "json/top-level-interop",
-				"url": "https://github.com/eslint/json/blob/main/docs/rules/top-level-interop.md"
-			}
-		],
-		"flint": {
-			"name": "topLevelInteroperability",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"topLevelRequires": {
-		"eslint": [
-			{
-				"name": "n/global-require",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/global-require.md"
-			}
-		],
-		"flint": {
-			"name": "topLevelRequires",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "CJS-specific"
-	},
-	"tripleSlashReferences": {
+	{
 		"deno": [
 			{
 				"name": "triple-slash-reference",
@@ -15482,10 +13371,7 @@
 		],
 		"flint": {
 			"name": "tripleSlashReferences",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -15495,7 +13381,7 @@
 			}
 		]
 	},
-	"tripleSlashReferenceValidity": {
+	{
 		"deno": [
 			{
 				"name": "no-invalid-triple-slash-references",
@@ -15504,14 +13390,11 @@
 		],
 		"flint": {
 			"name": "tripleSlashReferenceValidity",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"tsComments": {
+	{
 		"biome": [
 			{
 				"name": "noTsIgnore",
@@ -15532,10 +13415,7 @@
 		],
 		"flint": {
 			"name": "tsComments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -15549,7 +13429,7 @@
 			}
 		]
 	},
-	"tslintComments": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/ban-tslint-comment",
@@ -15558,10 +13438,7 @@
 		],
 		"flint": {
 			"name": "tslintComments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -15571,7 +13448,7 @@
 			}
 		]
 	},
-	"typeAssertions": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/consistent-type-assertions",
@@ -15580,14 +13457,11 @@
 		],
 		"flint": {
 			"name": "typeAssertions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"typeChecksTypeErrors": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-type-error",
@@ -15596,10 +13470,7 @@
 		],
 		"flint": {
 			"name": "typeChecksTypeErrors",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -15609,7 +13480,7 @@
 			}
 		]
 	},
-	"typeConstituentDuplicates": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-duplicate-type-constituents",
@@ -15618,10 +13489,7 @@
 		],
 		"flint": {
 			"name": "typeConstituentDuplicates",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -15631,7 +13499,7 @@
 			}
 		]
 	},
-	"typeExports": {
+	{
 		"biome": [
 			{
 				"name": "consistentTypeExports",
@@ -15646,14 +13514,11 @@
 		],
 		"flint": {
 			"name": "typeExports",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"typeImports": {
+	{
 		"biome": [
 			{
 				"name": "consistentTypeImports",
@@ -15672,10 +13537,7 @@
 		],
 		"flint": {
 			"name": "typeImports",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -15689,7 +13551,7 @@
 			}
 		]
 	},
-	"typeofComparisons": {
+	{
 		"biome": [
 			{
 				"name": "useValidTypeof",
@@ -15710,10 +13572,7 @@
 		],
 		"flint": {
 			"name": "typeofComparisons",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -15723,71 +13582,7 @@
 			}
 		]
 	},
-	"typePresence": {
-		"eslint": [
-			{
-				"name": "package-json/require-type",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-type.md"
-			}
-		],
-		"flint": {
-			"name": "typePresence",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"typeRequired": {
-		"eslint": [
-			{
-				"name": "package-json/type-required",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/type-required.md"
-			}
-		],
-		"flint": {
-			"name": "typeRequired",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"typesPresence": {
-		"eslint": [
-			{
-				"name": "package-json/require-types",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-types.md"
-			}
-		],
-		"flint": {
-			"name": "typesPresence",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "None"
-		}
-	},
-	"typeValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-type",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-type.md"
-			}
-		],
-		"flint": {
-			"name": "typeValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"unassignedImports": {
+	{
 		"eslint": [
 			{
 				"name": "import/no-unassigned-import",
@@ -15796,10 +13591,7 @@
 		],
 		"flint": {
 			"name": "unassignedImports",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -15809,7 +13601,7 @@
 			}
 		]
 	},
-	"unassignedVariables": {
+	{
 		"biome": [
 			{
 				"name": "noUnassignedVariables",
@@ -15824,10 +13616,7 @@
 		],
 		"flint": {
 			"name": "unassignedVariables",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -15837,7 +13626,7 @@
 			}
 		]
 	},
-	"unboundMethods": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/unbound-method",
@@ -15846,10 +13635,7 @@
 		],
 		"flint": {
 			"name": "unboundMethods",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -15859,24 +13645,7 @@
 			}
 		]
 	},
-	"undefined": {
-		"eslint": [
-			{
-				"name": "jsonc/no-undefined-value",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-undefined-value.html"
-			}
-		],
-		"flint": {
-			"name": "undefined",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"undefinedInitialValues": {
+	{
 		"biome": [
 			{
 				"name": "noUselessUndefinedInitialization",
@@ -15884,10 +13653,7 @@
 			}
 		],
 		"deno": [
-			{
-				"name": "no-undef",
-				"url": "https://docs.deno.com/lint/rules/no-undef"
-			}
+			{ "name": "no-undef", "url": "https://docs.deno.com/lint/rules/no-undef" }
 		],
 		"eslint": [
 			{
@@ -15897,14 +13663,11 @@
 		],
 		"flint": {
 			"name": "undefinedInitialValues",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"undefinedNames": {
+	{
 		"eslint": [
 			{
 				"name": "no-undefined",
@@ -15913,10 +13676,7 @@
 		],
 		"flint": {
 			"name": "undefinedNames",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -15926,7 +13686,7 @@
 			}
 		]
 	},
-	"undefinedTypeofChecks": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-typeof-undefined",
@@ -15935,10 +13695,7 @@
 		],
 		"flint": {
 			"name": "undefinedTypeofChecks",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -15949,7 +13706,7 @@
 			}
 		]
 	},
-	"undefinedVariables": {
+	{
 		"biome": [
 			{
 				"name": "noUndeclaredVariables",
@@ -15964,10 +13721,7 @@
 		],
 		"flint": {
 			"name": "undefinedVariables",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -15977,7 +13731,7 @@
 			}
 		]
 	},
-	"underscoreNames": {
+	{
 		"eslint": [
 			{
 				"name": "no-underscore-dangle",
@@ -15986,30 +13740,11 @@
 		],
 		"flint": {
 			"name": "underscoreNames",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"unescapedEntities": {
-		"deno": [
-			{
-				"name": "jsx-no-unescaped-entities",
-				"url": "https://docs.deno.com/lint/rules/jsx-no-unescaped-entities"
-			}
-		],
-		"flint": {
-			"name": "unescapedEntities",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"unicodeBOMs": {
+	{
 		"eslint": [
 			{
 				"name": "unicode-bom",
@@ -16018,10 +13753,7 @@
 		],
 		"flint": {
 			"name": "unicodeBOMs",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -16031,24 +13763,7 @@
 			}
 		]
 	},
-	"unicodeCodepointEscapes": {
-		"eslint": [
-			{
-				"name": "jsonc/no-unicode-codepoint-escapes",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-unicode-codepoint-escapes.html"
-			}
-		],
-		"flint": {
-			"name": "unicodeCodepointEscapes",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Not implementing"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	"unifiedSignatures": {
+	{
 		"biome": [
 			{
 				"name": "useUnifiedTypeSignatures",
@@ -16063,31 +13778,12 @@
 		],
 		"flint": {
 			"name": "unifiedSignatures",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical",
 			"strictness": "Strict"
 		}
 	},
-	"unionTypes": {
-		"eslint": [
-			{
-				"name": "perfectionist/sort-union-types",
-				"url": "https://perfectionist.dev/rules/sort-union-types"
-			}
-		],
-		"flint": {
-			"name": "unionTypes",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"unnecessaryBind": {
+	{
 		"eslint": [
 			{
 				"name": "no-extra-bind",
@@ -16096,10 +13792,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryBind",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -16109,7 +13802,7 @@
 			}
 		]
 	},
-	"unnecessaryBlocks": {
+	{
 		"biome": [
 			{
 				"name": "noUselessLoneBlockStatements",
@@ -16124,10 +13817,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryBlocks",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -16137,7 +13827,7 @@
 			}
 		]
 	},
-	"unnecessaryBooleanCasts": {
+	{
 		"biome": [
 			{
 				"name": "noExtraBooleanCast",
@@ -16158,10 +13848,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryBooleanCasts",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -16171,7 +13858,7 @@
 			}
 		]
 	},
-	"unnecessaryCatches": {
+	{
 		"biome": [
 			{
 				"name": "noUselessCatch",
@@ -16186,10 +13873,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryCatches",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -16199,13 +13883,10 @@
 			}
 		]
 	},
-	"unnecessaryComparisons": {
+	{
 		"flint": {
 			"name": "unnecessaryComparisons",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -16219,7 +13900,7 @@
 			}
 		]
 	},
-	"unnecessaryComputedKeys": {
+	{
 		"biome": [
 			{
 				"name": "useLiteralKeys",
@@ -16234,14 +13915,11 @@
 		],
 		"flint": {
 			"name": "unnecessaryComputedKeys",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"unnecessaryConcatentation": {
+	{
 		"biome": [
 			{
 				"name": "noUselessStringConcat",
@@ -16256,10 +13934,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryConcatentation",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -16269,7 +13944,7 @@
 			}
 		]
 	},
-	"unnecessaryConditions": {
+	{
 		"biome": [
 			{
 				"name": "noUnnecessaryConditions",
@@ -16284,14 +13959,11 @@
 		],
 		"flint": {
 			"name": "unnecessaryConditions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"unnecessaryConstructors": {
+	{
 		"biome": [
 			{
 				"name": "noUselessConstructor",
@@ -16310,10 +13982,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryConstructors",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -16323,7 +13992,7 @@
 			}
 		]
 	},
-	"unnecessaryContinues": {
+	{
 		"biome": [
 			{
 				"name": "noUselessContinue",
@@ -16332,14 +14001,11 @@
 		],
 		"flint": {
 			"name": "unnecessaryContinues",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"unnecessaryEscapes": {
+	{
 		"biome": [
 			{
 				"name": "noUselessEscapeInRegex",
@@ -16358,30 +14024,11 @@
 		],
 		"flint": {
 			"name": "unnecessaryEscapes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"unnecessaryFragments": {
-		"deno": [
-			{
-				"name": "jsx-no-useless-fragment",
-				"url": "https://docs.deno.com/lint/rules/jsx-no-useless-fragment"
-			}
-		],
-		"flint": {
-			"name": "unnecessaryFragments",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"unnecessaryFunctionCurries": {
+	{
 		"eslint": [
 			{
 				"name": "no-useless-call",
@@ -16390,10 +14037,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryFunctionCurries",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -16403,7 +14047,7 @@
 			}
 		]
 	},
-	"unnecessaryLabels": {
+	{
 		"biome": [
 			{
 				"name": "noUselessLabel",
@@ -16418,10 +14062,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryLabels",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -16431,7 +14072,7 @@
 			}
 		]
 	},
-	"unnecessaryLogicalComparisons": {
+	{
 		"biome": [
 			{
 				"name": "useSimplifiedLogicExpression",
@@ -16446,10 +14087,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryLogicalComparisons",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -16459,7 +14097,7 @@
 			}
 		]
 	},
-	"unnecessaryMathClamps": {
+	{
 		"biome": [
 			{
 				"name": "noConstantMathMinMaxClamp",
@@ -16468,10 +14106,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryMathClamps",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -16481,7 +14116,7 @@
 			}
 		]
 	},
-	"unnecessaryNumericFractions": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-zero-fractions",
@@ -16490,10 +14125,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryNumericFractions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -16503,7 +14135,7 @@
 			}
 		]
 	},
-	"unnecessaryPolyfills": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-unnecessary-polyfills",
@@ -16512,15 +14144,12 @@
 		],
 		"flint": {
 			"name": "unnecessaryPolyfills",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Superseded by the e18e initiative"
 	},
-	"unnecessaryRenames": {
+	{
 		"biome": [
 			{
 				"name": "noUselessRename",
@@ -16541,10 +14170,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryRenames",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -16554,7 +14180,7 @@
 			}
 		]
 	},
-	"unnecessaryReturns": {
+	{
 		"eslint": [
 			{
 				"name": "no-useless-return",
@@ -16563,14 +14189,11 @@
 		],
 		"flint": {
 			"name": "unnecessaryReturns",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"unnecessarySpreads": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-useless-spread",
@@ -16579,14 +14202,11 @@
 		],
 		"flint": {
 			"name": "unnecessarySpreads",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"unnecessaryStringRaws": {
+	{
 		"biome": [
 			{
 				"name": "noUselessStringRaw",
@@ -16595,14 +14215,11 @@
 		],
 		"flint": {
 			"name": "unnecessaryStringRaws",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"unnecessaryTemplateExpressions": {
+	{
 		"biome": [
 			{
 				"name": "noUnusedTemplateLiteral",
@@ -16617,10 +14234,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryTemplateExpressions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -16630,7 +14244,7 @@
 			}
 		]
 	},
-	"unnecessaryTernaries": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-logical-operator-over-ternary",
@@ -16639,10 +14253,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryTernaries",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic",
 			"strictness": "Strict"
 		},
@@ -16653,7 +14264,7 @@
 			}
 		]
 	},
-	"unnecessaryTypeAnnotations": {
+	{
 		"biome": [
 			{
 				"name": "noInferrableTypes",
@@ -16674,10 +14285,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryTypeAnnotations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -16687,7 +14295,7 @@
 			}
 		]
 	},
-	"unnecessaryTypeArguments": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unnecessary-type-arguments",
@@ -16696,10 +14304,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryTypeArguments",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -16709,7 +14314,7 @@
 			}
 		]
 	},
-	"unnecessaryTypeAssertions": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unnecessary-type-assertion",
@@ -16718,10 +14323,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryTypeAssertions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -16731,7 +14333,7 @@
 			}
 		]
 	},
-	"unnecessaryTypeConstraints": {
+	{
 		"biome": [
 			{
 				"name": "noUselessTypeConstraint",
@@ -16746,10 +14348,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryTypeConstraints",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -16759,7 +14358,7 @@
 			}
 		]
 	},
-	"unnecessaryTypeConversions": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unnecessary-type-conversion",
@@ -16768,14 +14367,11 @@
 		],
 		"flint": {
 			"name": "unnecessaryTypeConversions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"unnecessaryTypeParameters": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unnecessary-type-parameters",
@@ -16784,14 +14380,11 @@
 		],
 		"flint": {
 			"name": "unnecessaryTypeParameters",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"unnecessaryUndefinedDefaults": {
+	{
 		"biome": [
 			{
 				"name": "noUselessUndefined",
@@ -16806,10 +14399,7 @@
 		],
 		"flint": {
 			"name": "unnecessaryUndefinedDefaults",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -16819,7 +14409,7 @@
 			}
 		]
 	},
-	"unnecessaryUseStricts": {
+	{
 		"biome": [
 			{
 				"name": "noRedundantUseStrict",
@@ -16828,62 +14418,11 @@
 		],
 		"flint": {
 			"name": "unnecessaryUseStricts",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"unpublishedBins": {
-		"eslint": [
-			{
-				"name": "n/no-unpublished-bin",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unpublished-bin.md"
-			}
-		],
-		"flint": {
-			"name": "unpublishedBins",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Logical"
-		}
-	},
-	"unpublishedImports": {
-		"eslint": [
-			{
-				"name": "n/no-unpublished-import",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unpublished-import.md"
-			}
-		],
-		"flint": {
-			"name": "unpublishedImports",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Logical"
-		}
-	},
-	"unpublishedRequires": {
-		"eslint": [
-			{
-				"name": "n/no-unpublished-require",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unpublished-require.md"
-			}
-		],
-		"flint": {
-			"name": "unpublishedRequires",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Not implementing"
-		}
-	},
-	"unreachableLoops": {
+	{
 		"eslint": [
 			{
 				"name": "no-unreachable-loop",
@@ -16892,14 +14431,11 @@
 		],
 		"flint": {
 			"name": "unreachableLoops",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"unreachableStatements": {
+	{
 		"biome": [
 			{
 				"name": "noUnreachable",
@@ -16920,10 +14456,7 @@
 		],
 		"flint": {
 			"name": "unreachableStatements",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -16933,7 +14466,7 @@
 			}
 		]
 	},
-	"unsafeDeclarationmerging": {
+	{
 		"biome": [
 			{
 				"name": "noUnsafeDeclarationMerging",
@@ -16948,10 +14481,7 @@
 		],
 		"flint": {
 			"name": "unsafeDeclarationmerging",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -16961,7 +14491,7 @@
 			}
 		]
 	},
-	"unsafeEnumComparisons": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unsafe-enum-comparison",
@@ -16970,10 +14500,7 @@
 		],
 		"flint": {
 			"name": "unsafeEnumComparisons",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -16983,7 +14510,7 @@
 			}
 		]
 	},
-	"unsafeFinallyStatements": {
+	{
 		"biome": [
 			{
 				"name": "noUnsafeFinally",
@@ -17004,10 +14531,7 @@
 		],
 		"flint": {
 			"name": "unsafeFinallyStatements",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -17017,7 +14541,7 @@
 			}
 		]
 	},
-	"unsafeFunctionTypes": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unsafe-function-type",
@@ -17026,10 +14550,7 @@
 		],
 		"flint": {
 			"name": "unsafeFunctionTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -17039,7 +14560,7 @@
 			}
 		]
 	},
-	"unsafeNegations": {
+	{
 		"biome": [
 			{
 				"name": "noUnsafeNegation",
@@ -17060,10 +14581,7 @@
 		],
 		"flint": {
 			"name": "unsafeNegations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -17073,7 +14591,7 @@
 			}
 		]
 	},
-	"unsafeOptionalChains": {
+	{
 		"biome": [
 			{
 				"name": "noUnsafeOptionalChaining",
@@ -17088,10 +14606,7 @@
 		],
 		"flint": {
 			"name": "unsafeOptionalChains",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -17101,7 +14616,7 @@
 			}
 		]
 	},
-	"unsafeToString": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-base-to-string",
@@ -17110,10 +14625,7 @@
 		],
 		"flint": {
 			"name": "unsafeToString",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -17123,7 +14635,7 @@
 			}
 		]
 	},
-	"unsafeUnaryNegations": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unsafe-unary-minus",
@@ -17132,10 +14644,7 @@
 		],
 		"flint": {
 			"name": "unsafeUnaryNegations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -17145,55 +14654,7 @@
 			}
 		]
 	},
-	"unsupportedGlobals": {
-		"eslint": [
-			{
-				"name": "n/no-unsupported-features/es-builtins",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unsupported-features.md"
-			}
-		],
-		"flint": {
-			"name": "unsupportedGlobals",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Logical"
-		}
-	},
-	"unsupportedNodeAPIs": {
-		"eslint": [
-			{
-				"name": "n/no-unsupported-features/node-builtins",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unsupported-features.md"
-			}
-		],
-		"flint": {
-			"name": "unsupportedNodeAPIs",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Logical"
-		}
-	},
-	"unsupportedSyntax": {
-		"eslint": [
-			{
-				"name": "n/no-unsupported-features/es-syntax",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unsupported-features.md"
-			}
-		],
-		"flint": {
-			"name": "unsupportedSyntax",
-			"plugin": {
-				"code": "node",
-				"name": "Node"
-			},
-			"preset": "Logical"
-		}
-	},
-	"unusedCatchBindings": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/prefer-optional-catch-binding",
@@ -17202,10 +14663,7 @@
 		],
 		"flint": {
 			"name": "unusedCatchBindings",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"notes": "Superseded by unusedVariables",
@@ -17216,7 +14674,7 @@
 			}
 		]
 	},
-	"unusedExpressions": {
+	{
 		"eslint": [
 			{
 				"name": "no-unused-expressions",
@@ -17229,10 +14687,7 @@
 		],
 		"flint": {
 			"name": "unusedExpressions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -17242,7 +14697,7 @@
 			}
 		]
 	},
-	"unusedLabels": {
+	{
 		"biome": [
 			{
 				"name": "noUnusedLabels",
@@ -17263,10 +14718,7 @@
 		],
 		"flint": {
 			"name": "unusedLabels",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -17276,7 +14728,7 @@
 			}
 		]
 	},
-	"unusedObjectProperties": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/no-unused-properties",
@@ -17285,14 +14737,11 @@
 		],
 		"flint": {
 			"name": "unusedObjectProperties",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"unusedPrivateClassMembers": {
+	{
 		"biome": [
 			{
 				"name": "noUnusedPrivateClassMembers",
@@ -17307,10 +14756,7 @@
 		],
 		"flint": {
 			"name": "unusedPrivateClassMembers",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -17320,7 +14766,7 @@
 			}
 		]
 	},
-	"unusedSwitchStatements": {
+	{
 		"biome": [
 			{
 				"name": "noUselessSwitchCase",
@@ -17335,10 +14781,7 @@
 		],
 		"flint": {
 			"name": "unusedSwitchStatements",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -17348,7 +14791,7 @@
 			}
 		]
 	},
-	"unusedValues": {
+	{
 		"eslint": [
 			{
 				"name": "no-useless-assignment",
@@ -17357,14 +14800,11 @@
 		],
 		"flint": {
 			"name": "unusedValues",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"unusedVariables": {
+	{
 		"biome": [
 			{
 				"name": "noUnusedFunctionParameters",
@@ -17393,10 +14833,7 @@
 		],
 		"flint": {
 			"name": "unusedVariables",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -17406,7 +14843,7 @@
 			}
 		]
 	},
-	"urlRelativity": {
+	{
 		"eslint": [
 			{
 				"name": "unicorn/relative-url-style",
@@ -17415,14 +14852,11 @@
 		],
 		"flint": {
 			"name": "urlRelativity",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"usageBeforeDefinition": {
+	{
 		"biome": [
 			{
 				"name": "noInvalidUseBeforeDeclaration",
@@ -17441,91 +14875,37 @@
 		],
 		"flint": {
 			"name": "usageBeforeDefinition",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		}
 	},
-	"useStrictDirectives": {
+	{
 		"eslint": [
-			{
-				"name": "strict",
-				"url": "https://eslint.org/docs/latest/rules/strict"
-			}
+			{ "name": "strict", "url": "https://eslint.org/docs/latest/rules/strict" }
 		],
 		"flint": {
 			"name": "useStrictDirectives",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		}
 	},
-	"validElementChildren": {
-		"deno": [
-			{
-				"name": "jsx-void-dom-elements-no-children",
-				"url": "https://docs.deno.com/lint/rules/jsx-void-dom-elements-no-children"
-			}
-		],
-		"flint": {
-			"name": "validElementChildren",
-			"plugin": {
-				"code": "jsx",
-				"name": "JSX"
-			},
-			"preset": "Logical",
-			"strictness": "Strict"
-		}
-	},
-	"valueSafety": {
-		"eslint": [
-			{
-				"name": "json/no-unsafe-values",
-				"url": "https://github.com/eslint/json/blob/main/docs/rules/no-unsafe-values.md"
-			}
-		],
-		"flint": {
-			"name": "valueSafety",
-			"plugin": {
-				"code": "json",
-				"name": "JSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"varDeclarations": {
+	{
 		"biome": [
-			{
-				"name": "noVar",
-				"url": "https://biomejs.dev/linter/rules/noVar"
-			}
+			{ "name": "noVar", "url": "https://biomejs.dev/linter/rules/noVar" }
 		],
 		"deno": [
-			{
-				"name": "no-var",
-				"url": "https://docs.deno.com/lint/rules/no-var"
-			}
+			{ "name": "no-var", "url": "https://docs.deno.com/lint/rules/no-var" }
 		],
 		"eslint": [
-			{
-				"name": "no-var",
-				"url": "https://eslint.org/docs/latest/rules/no-var"
-			}
+			{ "name": "no-var", "url": "https://eslint.org/docs/latest/rules/no-var" }
 		],
 		"flint": {
 			"name": "varDeclarations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		}
 	},
-	"variableBlockScopeUsage": {
+	{
 		"eslint": [
 			{
 				"name": "block-scoped-var",
@@ -17534,10 +14914,7 @@
 		],
 		"flint": {
 			"name": "variableBlockScopeUsage",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -17547,7 +14924,7 @@
 			}
 		]
 	},
-	"variableDeclarationInitializations": {
+	{
 		"eslint": [
 			{
 				"name": "init-declarations",
@@ -17560,10 +14937,7 @@
 		],
 		"flint": {
 			"name": "variableDeclarationInitializations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -17573,23 +14947,7 @@
 			}
 		]
 	},
-	"variableDeclarations": {
-		"eslint": [
-			{
-				"name": "perfectionist/sort-variable-declarations",
-				"url": "https://perfectionist.dev/rules/sort-variable-declarations"
-			}
-		],
-		"flint": {
-			"name": "variableDeclarations",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
-			"preset": "Stylistic"
-		}
-	},
-	"variableDeclarationSorting": {
+	{
 		"eslint": [
 			{
 				"name": "sort-vars",
@@ -17598,10 +14956,7 @@
 		],
 		"flint": {
 			"name": "variableDeclarationSorting",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -17611,7 +14966,7 @@
 			}
 		]
 	},
-	"variableDeletions": {
+	{
 		"deno": [
 			{
 				"name": "no-delete-var",
@@ -17626,10 +14981,7 @@
 		],
 		"flint": {
 			"name": "variableDeletions",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -17639,7 +14991,7 @@
 			}
 		]
 	},
-	"variableRedeclarations": {
+	{
 		"biome": [
 			{
 				"name": "noRedeclare",
@@ -17664,10 +15016,7 @@
 		],
 		"flint": {
 			"name": "variableRedeclarations",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Untyped"
 		},
 		"oxlint": [
@@ -17677,7 +15026,7 @@
 			}
 		]
 	},
-	"variablesOnTop": {
+	{
 		"eslint": [
 			{
 				"name": "vars-on-top",
@@ -17686,10 +15035,7 @@
 		],
 		"flint": {
 			"name": "variablesOnTop",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		},
 		"oxlint": [
@@ -17699,7 +15045,7 @@
 			}
 		]
 	},
-	"verbatimModuleSyntax": {
+	{
 		"deno": [
 			{
 				"name": "verbatim-module-syntax",
@@ -17708,51 +15054,13 @@
 		],
 		"flint": {
 			"name": "verbatimModuleSyntax",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Not implementing"
 		}
 	},
-	"versionPresence": {
-		"eslint": [
-			{
-				"name": "package-json/require-version",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/require-version.md"
-			}
-		],
-		"flint": {
-			"name": "versionPresence",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"versionValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-version",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-version.md"
-			}
-		],
-		"flint": {
-			"name": "versionValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"voidOperator": {
+	{
 		"biome": [
-			{
-				"name": "noVoid",
-				"url": "https://biomejs.dev/linter/rules/noVoid"
-			}
+			{ "name": "noVoid", "url": "https://biomejs.dev/linter/rules/noVoid" }
 		],
 		"eslint": [
 			{
@@ -17762,10 +15070,7 @@
 		],
 		"flint": {
 			"name": "voidOperator",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Stylistic"
 		},
 		"oxlint": [
@@ -17775,40 +15080,12 @@
 			}
 		]
 	},
-	"windowMessagingTargetOrigin": {
-		"eslint": [
-			{
-				"name": "unicorn/require-post-message-target-origin",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/require-post-message-target-origin.md"
-			}
-		],
-		"flint": {
-			"name": "windowMessagingTargetOrigin",
-			"plugin": {
-				"code": "browser",
-				"name": "Browser"
-			},
-			"preset": "Not implementing"
-		},
-		"oxlint": [
-			{
-				"name": "unicorn/require-post-message-target-origin",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/require-post-message-target-origin.html"
-			}
-		]
-	},
-	"withStatements": {
+	{
 		"biome": [
-			{
-				"name": "noWith",
-				"url": "https://biomejs.dev/linter/rules/noWith"
-			}
+			{ "name": "noWith", "url": "https://biomejs.dev/linter/rules/noWith" }
 		],
 		"deno": [
-			{
-				"name": "no-with",
-				"url": "https://docs.deno.com/lint/rules/no-with"
-			}
+			{ "name": "no-with", "url": "https://docs.deno.com/lint/rules/no-with" }
 		],
 		"eslint": [
 			{
@@ -17818,10 +15095,7 @@
 		],
 		"flint": {
 			"name": "withStatements",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		},
 		"oxlint": [
@@ -17831,23 +15105,7 @@
 			}
 		]
 	},
-	"workspacesValidity": {
-		"eslint": [
-			{
-				"name": "package-json/valid-workspaces",
-				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/HEAD/docs/rules/valid-workspaces.md"
-			}
-		],
-		"flint": {
-			"name": "workspacesValidity",
-			"plugin": {
-				"code": "package-json",
-				"name": "PackageJSON"
-			},
-			"preset": "Logical"
-		}
-	},
-	"wrapperObjectTypes": {
+	{
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-wrapper-object-types",
@@ -17856,43 +15114,169 @@
 		],
 		"flint": {
 			"name": "wrapperObjectTypes",
-			"plugin": {
-				"code": "ts",
-				"name": "TypeScript"
-			},
+			"plugin": { "code": "ts", "name": "TypeScript" },
 			"preset": "Logical"
 		}
 	},
-	"ymlKeys": {
+	{
 		"eslint": [
 			{
-				"name": "yml/sort-keys",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/sort-keys.html"
+				"name": "yml/block-mapping",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/block-mapping.html"
 			}
 		],
 		"flint": {
-			"name": "ymlKeys",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
+			"name": "blockMappings",
+			"plugin": { "code": "yml", "name": "YML" },
 			"preset": "Stylistic"
 		}
 	},
-	"ymlSequenceValues": {
+	{
 		"eslint": [
 			{
-				"name": "yml/sort-sequence-values",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/sort-sequence-values.html"
+				"name": "yml/block-sequence",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/block-sequence.html"
 			}
 		],
 		"flint": {
-			"name": "ymlSequenceValues",
-			"plugin": {
-				"code": "sorting",
-				"name": "Sorting"
-			},
+			"name": "blockSequences",
+			"plugin": { "code": "yml", "name": "YML" },
 			"preset": "Stylistic"
 		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "yml/no-empty-document",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-document.html"
+			}
+		],
+		"flint": {
+			"name": "emptyDocuments",
+			"plugin": { "code": "yml", "name": "YML" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "yml/no-empty-key",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-key.html"
+			}
+		],
+		"flint": {
+			"implemented": true,
+			"name": "emptyMappingKeys",
+			"plugin": { "code": "yml", "name": "YML" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "yml/no-empty-mapping-value",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-mapping-value.html"
+			}
+		],
+		"flint": {
+			"name": "emptyMappingValues",
+			"plugin": { "code": "yml", "name": "YML" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "yml/no-empty-sequence-entry",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-sequence-entry.html"
+			}
+		],
+		"flint": {
+			"name": "emptySequenceEntries",
+			"plugin": { "code": "yml", "name": "YML" },
+			"preset": "Logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "yml/file-extension",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/file-extension.html"
+			}
+		],
+		"flint": {
+			"name": "fileExtensions",
+			"plugin": { "code": "yml", "name": "YML" },
+			"preset": "Stylistic",
+			"strictness": "Strict"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "yml/no-irregular-whitespace",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-irregular-whitespace.html"
+			}
+		],
+		"flint": {
+			"name": "irregularWhitespace",
+			"plugin": { "code": "yml", "name": "YML" },
+			"preset": "Stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "yml/key-name-casing",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/key-name-casing.html"
+			}
+		],
+		"flint": {
+			"name": "mappingKeyCasing",
+			"plugin": { "code": "yml", "name": "YML" },
+			"preset": "Not implementing"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "yml/no-trailing-zeros",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-trailing-zeros.html"
+			}
+		],
+		"flint": {
+			"name": "numericTrailingZeros",
+			"plugin": { "code": "yml", "name": "YML" },
+			"preset": "Stylistic",
+			"strictness": "Strict"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "yml/plain-scalar",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/plain-scalar.html"
+			}
+		],
+		"flint": {
+			"name": "plainScalars",
+			"plugin": { "code": "yml", "name": "YML" },
+			"preset": "Stylistic",
+			"strictness": "Strict"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "yml/require-string-key",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/require-string-key.html"
+			}
+		],
+		"flint": {
+			"name": "stringMappingKeys",
+			"plugin": { "code": "yml", "name": "YML" },
+			"preset": "Logical",
+			"strictness": "Strict"
+		}
 	}
-}
+]

--- a/packages/comparisons/src/index.ts
+++ b/packages/comparisons/src/index.ts
@@ -1,8 +1,21 @@
-import dataRaw from "./data.json" with { type: "json" };
+import data from "./data.json" with { type: "json" };
 
-const data: Record<string, Rule> = dataRaw;
+export function getComparisonId(pluginId: string, ruleId: string) {
+	return [pluginId, ruleId].join("/");
+}
 
-export { data };
+const comparisons: Comparison[] = data;
+
+export { comparisons };
+
+export interface Comparison {
+	biome?: LinterRuleReference[];
+	deno?: LinterRuleReference[];
+	eslint?: LinterRuleReference[];
+	flint: FlintRuleReference;
+	notes?: string;
+	oxlint?: LinterRuleReference[];
+}
 
 export interface FlintRulePluginReference {
 	code: string;
@@ -22,13 +35,4 @@ export type Linter = "biome" | "deno" | "eslint" | "oxlint";
 export interface LinterRuleReference {
 	name: string;
 	url: string;
-}
-
-export interface Rule {
-	biome?: LinterRuleReference[];
-	deno?: LinterRuleReference[];
-	eslint?: LinterRuleReference[];
-	flint: FlintRuleReference;
-	notes?: string;
-	oxlint?: LinterRuleReference[];
 }

--- a/packages/json/src/plugin.ts
+++ b/packages/json/src/plugin.ts
@@ -1,11 +1,11 @@
 import { createPlugin } from "@flint.fyi/core";
 
-import duplicateKeys from "./rules/duplicateKeys.js";
+import keyDuplicates from "./rules/keyDuplicates.js";
 
 export const json = createPlugin({
 	files: {
 		all: ["**/*.json"],
 	},
 	name: "json",
-	rules: [duplicateKeys],
+	rules: [keyDuplicates],
 });

--- a/packages/json/src/rules/keyDuplicates.test.ts
+++ b/packages/json/src/rules/keyDuplicates.test.ts
@@ -1,4 +1,4 @@
-import rule from "./duplicateKeys.js";
+import rule from "./keyDuplicates.js";
 import { ruleTester } from "./ruleTester.js";
 
 ruleTester.describe(rule, {

--- a/packages/json/src/rules/keyDuplicates.ts
+++ b/packages/json/src/rules/keyDuplicates.ts
@@ -7,7 +7,7 @@ export default jsonLanguage.createRule({
 	about: {
 		description:
 			"Reports unnecessary duplicate keys that override previous values.",
-		id: "duplicateKeys",
+		id: "keyDuplicates",
 		preset: "logical",
 	},
 	messages: {

--- a/packages/site/src/components/RuleEquivalentLinks.module.css
+++ b/packages/site/src/components/RuleEquivalentLinks.module.css
@@ -1,0 +1,12 @@
+.ruleEquivalentLinks {
+	padding: 0.25rem;
+}
+
+.ruleEquivalentLinks:first-of-type {
+	padding-left: 0;
+}
+
+.ruleEquivalentLinks code {
+	padding: 0.125rem 0.2rem;
+	font-size: var(--font-size-table);
+}

--- a/packages/site/src/components/RuleEquivalentLinks.tsx
+++ b/packages/site/src/components/RuleEquivalentLinks.tsx
@@ -1,0 +1,23 @@
+import type { Linter, Comparison } from "@flint.fyi/comparisons";
+
+import styles from "./RuleEquivalentLinks.module.css";
+
+export interface RuleEquivalentLinksProps {
+	comparison: Comparison;
+	linter: Linter;
+}
+
+export function RuleEquivalentLinks({
+	comparison,
+	linter,
+}: RuleEquivalentLinksProps) {
+	return (
+		<td className={styles.ruleEquivalentLinks}>
+			{comparison[linter]?.map((reference) => (
+				<a href={reference.url} key={reference.name} target="_blank">
+					<code>{reference.name}</code>
+				</a>
+			))}
+		</td>
+	);
+}

--- a/packages/site/src/components/RuleEquivalentsTable.astro
+++ b/packages/site/src/components/RuleEquivalentsTable.astro
@@ -1,0 +1,39 @@
+---
+import { getComparisonByFlintId } from "./comparisonsByFlintId";
+import { RuleEquivalentLinks } from "./RuleEquivalentLinks";
+
+interface Props {
+	pluginId: string;
+	ruleId: string;
+}
+
+const { pluginId, ruleId } = Astro.props;
+const comparison = getComparisonByFlintId(pluginId, ruleId);
+---
+
+<table class="rule-equivalents-table">
+	<thead>
+		<th>Biome</th>
+		<th>Deno Lint</th>
+		<th>ESLint</th>
+		<th>Oxlint</th>
+	</thead>
+	<tbody>
+		<RuleEquivalentLinks comparison={comparison} linter="biome" />
+		<RuleEquivalentLinks comparison={comparison} linter="deno" />
+		<RuleEquivalentLinks comparison={comparison} linter="eslint" />
+		<RuleEquivalentLinks comparison={comparison} linter="oxlint" />
+	</tbody>
+</table>
+
+<style>
+	table {
+		display: table;
+		table-layout: fixed;
+		width: 100%;
+	}
+
+	th {
+		padding: 0.25rem;
+	}
+</style>

--- a/packages/site/src/components/RuleSummary.astro
+++ b/packages/site/src/components/RuleSummary.astro
@@ -1,30 +1,14 @@
 ---
 import markdownIt from "markdown-it";
-
-const renderer = markdownIt();
+import { getRuleForPlugin } from "./getRuleForPlugin";
 
 interface Props {
 	plugin: string;
 	rule: string;
 }
 
-import { cspell } from "@flint.fyi/plugin-cspell";
-import { flint } from "@flint.fyi/plugin-flint";
-import { json, md, ts, yml } from "flint";
-
-const { plugin: pluginId, rule: ruleId } = Astro.props;
-const plugins = { cspell, json, flint, md, ts, yml };
-
-if (!(pluginId in plugins)) {
-	throw new Error(`Unknown RuleCards plugin: ${pluginId}.`);
-}
-
-const plugin = plugins[pluginId as keyof typeof plugins];
-const rule = plugin.rulesById.get(ruleId);
-
-if (!rule) {
-	throw new Error(`Unknown rule for ${pluginId}: ${ruleId}.`);
-}
+const renderer = markdownIt();
+const rule = getRuleForPlugin(Astro.props.plugin, Astro.props.rule);
 ---
 
 <blockquote>
@@ -33,8 +17,8 @@ if (!rule) {
 
 <blockquote>
 	✅ This rule is included in the{" "}
-	<a href={`/rules/${pluginId}/about#${rule.about.preset}`}>
-		{pluginId}
+	<a href={`/rules/${Astro.props.plugin}/about#${rule.about.preset}`}>
+		{Astro.props.plugin}
 		{rule.about.preset} preset</a
 	>.
 </blockquote>

--- a/packages/site/src/components/RulesTable.tsx
+++ b/packages/site/src/components/RulesTable.tsx
@@ -1,14 +1,13 @@
 import {
-	data,
-	type FlintRulePluginReference,
+	comparisons,
 	type FlintRuleReference,
-	type Linter,
-	type Rule,
+	type Comparison,
 } from "@flint.fyi/comparisons" with { type: "json" };
 
 import styles from "./RulesTable.module.css";
+import { RuleEquivalentLinks } from "./RuleEquivalentLinks";
 
-function getSortKey(rule: Rule) {
+function getSortKey(rule: Comparison) {
 	return [
 		rule.flint.plugin.name,
 		rule.flint.preset,
@@ -19,27 +18,10 @@ function getSortKey(rule: Rule) {
 		.replace("Not implemented", "Z-Not-implemented");
 }
 
-function renderFlintPreset(flint: Rule["flint"]) {
+function renderFlintPreset(flint: Comparison["flint"]) {
 	return flint.strictness
 		? `${flint.preset} (${flint.strictness})`
 		: flint.preset;
-}
-
-function renderLinks(linter: Linter, rule: Rule) {
-	if (!rule[linter]) {
-		return undefined;
-	}
-
-	return rule[linter].map((reference) => (
-		<a
-			data-wat={JSON.stringify(reference)}
-			href={reference.url}
-			key={reference.name}
-			target="_blank"
-		>
-			<code>{reference.name}</code>
-		</a>
-	));
 }
 
 export interface RulesTableProps {
@@ -56,7 +38,7 @@ function renderFlintName(flint: FlintRuleReference) {
 	);
 }
 
-function renderImplemented(values: Rule[]) {
+function renderImplemented(values: Comparison[]) {
 	const count = values.filter((value) => value.flint.implemented).length;
 
 	return (
@@ -68,9 +50,10 @@ function renderImplemented(values: Rule[]) {
 }
 
 export function RulesTable({ implementing }: RulesTableProps) {
-	const values = Object.values(data)
+	const values = comparisons
 		.filter(
-			(rule) => (rule.flint.preset !== "Not implementing") === implementing,
+			(comparison) =>
+				(comparison.flint.preset !== "Not implementing") === implementing,
 		)
 		.sort((a, b) => getSortKey(a).localeCompare(getSortKey(b)));
 
@@ -102,10 +85,10 @@ export function RulesTable({ implementing }: RulesTableProps) {
 							</td>
 							<td> {rule.flint.plugin.name}</td>
 							{implementing && <td>{renderFlintPreset(rule.flint)}</td>}
-							<td>{renderLinks("biome", rule)}</td>
-							<td>{renderLinks("deno", rule)}</td>
-							<td>{renderLinks("eslint", rule)}</td>
-							<td>{renderLinks("oxlint", rule)}</td>
+							<RuleEquivalentLinks comparison={rule} linter="biome" />
+							<RuleEquivalentLinks comparison={rule} linter="deno" />
+							<RuleEquivalentLinks comparison={rule} linter="eslint" />
+							<RuleEquivalentLinks comparison={rule} linter="oxlint" />
 							{!implementing && <td>{rule.notes}</td>}
 						</tr>
 					))}

--- a/packages/site/src/components/comparisonsByFlintId.ts
+++ b/packages/site/src/components/comparisonsByFlintId.ts
@@ -1,0 +1,12 @@
+import { comparisons, getComparisonId } from "@flint.fyi/comparisons";
+
+const comparisonsByFlintId = Object.fromEntries(
+	comparisons.map((comparison) => [
+		getComparisonId(comparison.flint.plugin.code, comparison.flint.name),
+		comparison,
+	]),
+);
+
+export function getComparisonByFlintId(pluginId: string, ruleId: string) {
+	return comparisonsByFlintId[getComparisonId(pluginId, ruleId)];
+}

--- a/packages/site/src/components/getRuleForPlugin.ts
+++ b/packages/site/src/components/getRuleForPlugin.ts
@@ -1,0 +1,20 @@
+import { cspell } from "@flint.fyi/plugin-cspell";
+import { flint } from "@flint.fyi/plugin-flint";
+import { type AnyRule, json, md, ts, yml } from "flint";
+
+const plugins = { cspell, flint, json, md, ts, yml };
+
+export function getRuleForPlugin(pluginId: string, ruleId: string): AnyRule {
+	if (!(pluginId in plugins)) {
+		throw new Error(`Unknown Flint plugin: ${pluginId}.`);
+	}
+
+	const plugin = plugins[pluginId as keyof typeof plugins];
+	const rule = plugin.rulesById.get(ruleId);
+
+	if (!rule) {
+		throw new Error(`Unknown rule for ${pluginId}: ${ruleId}.`);
+	}
+
+	return rule as AnyRule;
+}

--- a/packages/site/src/content/docs/rules/cspell/spelling.mdx
+++ b/packages/site/src/content/docs/rules/cspell/spelling.mdx
@@ -4,6 +4,7 @@ title: "spelling"
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
+import RuleEquivalentsTable from "~/components/RuleEquivalentsTable.astro";
 import RuleSummary from "~/components/RuleSummary.astro";
 
 <RuleSummary plugin="cspell" rule="spelling" />

--- a/packages/site/src/content/docs/rules/flint/duplicateTestCases.mdx
+++ b/packages/site/src/content/docs/rules/flint/duplicateTestCases.mdx
@@ -4,6 +4,7 @@ title: "duplicateTestCases"
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
+import RuleEquivalentsTable from "~/components/RuleEquivalentsTable.astro";
 import RuleSummary from "~/components/RuleSummary.astro";
 
 <RuleSummary plugin="flint" rule="duplicateTestCases" />

--- a/packages/site/src/content/docs/rules/json/duplicateKeys.mdx
+++ b/packages/site/src/content/docs/rules/json/duplicateKeys.mdx
@@ -1,12 +1,13 @@
 ---
 description: "Consecutive non-null assertion operators are unnecessary."
-title: "duplicateKeys"
+title: "keyDuplicates"
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
+import RuleEquivalentsTable from "~/components/RuleEquivalentsTable.astro";
 import RuleSummary from "~/components/RuleSummary.astro";
 
-<RuleSummary plugin="json" rule="duplicateKeys" />
+<RuleSummary plugin="json" rule="keyDuplicates" />
 
 Although JSON technically allows duplicate keys, using them is at best confusing.
 Most JSON parsers will ignore all but the last value for a given key.
@@ -48,7 +49,7 @@ This can be useful for projects that store extra information as comments in JSON
 
 ```ts
 json.rules({
-	duplicateKeys: {
+	keyDuplicates: {
 		allowKeys: ["//"],
 	},
 });
@@ -81,3 +82,7 @@ json.rules({
 
 If your project is a rare one that intentionally goes against standard conventions for JSON, you can turn off this rule.
 You might consider using [Flint disable comments](/) and/ [configuration file disables](/) for those specific situations instead of completely disabling this rule.
+
+## Equivalents in Other Linters
+
+<RuleEquivalentsTable pluginId="json" ruleId="keyDuplicates" />

--- a/packages/site/src/content/docs/rules/md/headingIncrements.mdx
+++ b/packages/site/src/content/docs/rules/md/headingIncrements.mdx
@@ -4,6 +4,7 @@ title: "headingIncrements"
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
+import RuleEquivalentsTable from "~/components/RuleEquivalentsTable.astro";
 import RuleSummary from "~/components/RuleSummary.astro";
 
 <RuleSummary plugin="md" rule="headingIncrements" />
@@ -42,3 +43,7 @@ This rule is not configurable.
 ## Further Reading
 
 - [W3 WAI Headings tutorial](https://www.w3.org/WAI/tutorials/page-structure/headings)
+
+## Equivalents in Other Linters
+
+<RuleEquivalentsTable pluginId="md" ruleId="headingIncrements" />

--- a/packages/site/src/content/docs/rules/ts/consecutiveNonNullAssertions.mdx
+++ b/packages/site/src/content/docs/rules/ts/consecutiveNonNullAssertions.mdx
@@ -4,6 +4,7 @@ title: "consecutiveNonNullAssertions"
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
+import RuleEquivalentsTable from "~/components/RuleEquivalentsTable.astro";
 import RuleSummary from "~/components/RuleSummary.astro";
 
 <RuleSummary plugin="ts" rule="consecutiveNonNullAssertions" />
@@ -41,3 +42,7 @@ This rule is not configurable.
 ## When Not To Use It
 
 There are no situations where it is beneficial to include extra chains of `!!`s.
+
+## Equivalents in Other Linters
+
+<RuleEquivalentsTable pluginId="ts" ruleId="consecutiveNonNullAssertions" />

--- a/packages/site/src/content/docs/rules/ts/forInArrays.mdx
+++ b/packages/site/src/content/docs/rules/ts/forInArrays.mdx
@@ -4,6 +4,7 @@ title: "forInArrays"
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
+import RuleEquivalentsTable from "~/components/RuleEquivalentsTable.astro";
 import RuleSummary from "~/components/RuleSummary.astro";
 
 <RuleSummary plugin="ts" rule="forInArrays" />
@@ -48,4 +49,8 @@ This rule is not configurable.
 ## When Not To Use It
 
 If your project is a rare one that intentionally loops over string indices of arrays, you can turn off this rule.
-You might consider using [Flint disable comments](/) and/ [configuration file disables](/) for those specific situations instead of completely disabling this rule.
+You might consider using [Flint disable comments](/) and/or [configuration file disables](/) for those specific situations instead of completely disabling this rule.
+
+## Equivalents in Other Linters
+
+<RuleEquivalentsTable pluginId="ts" ruleId="forInArrays" />

--- a/packages/site/src/content/docs/rules/ts/namespaceDeclarations.mdx
+++ b/packages/site/src/content/docs/rules/ts/namespaceDeclarations.mdx
@@ -4,6 +4,7 @@ title: "namespaceDeclarations"
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
+import RuleEquivalentsTable from "~/components/RuleEquivalentsTable.astro";
 import RuleSummary from "~/components/RuleSummary.astro";
 
 <RuleSummary plugin="ts" rule="namespaceDeclarations" />
@@ -130,3 +131,7 @@ You might consider using [Flint disable comments](/) and/ [configuration file di
 - [TypeScript handbook entry on Modules](https://www.typescriptlang.org/docs/handbook/modules.html)
 - [TypeScript handbook entry on Namespaces](https://www.typescriptlang.org/docs/handbook/namespaces.html)
 - [TypeScript handbook entry on Namespaces and Modules](https://www.typescriptlang.org/docs/handbook/namespaces-and-modules.html)
+
+## Equivalents in Other Linters
+
+<RuleEquivalentsTable pluginId="ts" ruleId="namespaceDeclarations" />

--- a/packages/site/src/content/docs/rules/yml/emptyMappingKeys.mdx
+++ b/packages/site/src/content/docs/rules/yml/emptyMappingKeys.mdx
@@ -4,6 +4,7 @@ title: "emptyMappingKeys"
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
+import RuleEquivalentsTable from "~/components/RuleEquivalentsTable.astro";
 import RuleSummary from "~/components/RuleSummary.astro";
 
 <RuleSummary plugin="yml" rule="emptyMappingKeys" />
@@ -33,3 +34,7 @@ Even if allowed by a parser, empty keys can be confusing for developers and lead
 ## Options
 
 This rule is not configurable.
+
+## Equivalents in Other Linters
+
+<RuleEquivalentsTable pluginId="yml" ruleId="emptyMappingKeys" />

--- a/packages/site/src/styles.css
+++ b/packages/site/src/styles.css
@@ -35,3 +35,8 @@
 :root {
 	--sl-content-width: 63rem;
 }
+
+/* Introduced tokens. */
+:root {
+	--font-size-table: 70%;
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #289
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Restructures the `@flint.fyi/comparisons` data to be a raw array of comparisons, not a string-to-comparison object. Those string keys never really made sense because plugins might have rules with similar names (e.g. `keyDuplicates`).

❤️‍🔥