### PR TITLE
fix(cli): move wrap-ansi dep into package

### DIFF
--- a/.changeset/fancy-schools-relax.md
+++ b/.changeset/fancy-schools-relax.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/cli": patch
+---
+
+move wrap-ansi dep into package

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
 		"*": "prettier --ignore-unknown --write"
 	},
 	"dependencies": {
-		"wrap-ansi": "^9.0.0",
 		"zod": "^4.0.0"
 	},
 	"devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,8 @@
 		"cli-cursor": "^5.0.0",
 		"debounce": "^2.2.0",
 		"debug-for-file": "^0.2.0",
-		"text-table-fast": "^0.1.0"
+		"text-table-fast": "^0.1.0",
+		"wrap-ansi": "^9.0.0"
 	},
 	"engines": {
 		"node": ">=24.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      wrap-ansi:
-        specifier: ^9.0.0
-        version: 9.0.0
       zod:
         specifier: ^4.0.0
         version: 4.0.17
@@ -147,6 +144,9 @@ importers:
       text-table-fast:
         specifier: ^0.1.0
         version: 0.1.0
+      wrap-ansi:
+        specifier: ^9.0.0
+        version: 9.0.0
 
   packages/comparisons: {}
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #315
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`wrap-ansi` is only ever used once, in the `@flint.fyi/cli` package.

❤️‍🔥