### PR TITLE
fix(rule-tester): corrected logic and types for current-file suggestions

### DIFF
--- a/.changeset/calm-sites-melt.md
+++ b/.changeset/calm-sites-melt.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/rule-tester": patch
+---
+
+corrected logic and types for current-file suggestions

--- a/packages/rule-tester/src/predicates.ts
+++ b/packages/rule-tester/src/predicates.ts
@@ -1,0 +1,7 @@
+import { TestSuggestion, TestSuggestionForFiles } from "./types.js";
+
+export function isTestSuggestionForFiles(
+	suggestion: TestSuggestion,
+): suggestion is TestSuggestionForFiles {
+	return "files" in suggestion;
+}

--- a/packages/rule-tester/src/resolveReportedSuggestions.test.ts
+++ b/packages/rule-tester/src/resolveReportedSuggestions.test.ts
@@ -68,11 +68,6 @@ describe("resolveReportedSuggestions", () => {
 			],
 		};
 
-		const result = resolveReportedSuggestions([report], {
-			...mockTestCaseNormalized,
-			suggestions: undefined,
-		});
-
 		expect(() =>
 			resolveReportedSuggestions([report], {
 				...mockTestCaseNormalized,

--- a/packages/rule-tester/src/resolveReportedSuggestions.test.ts
+++ b/packages/rule-tester/src/resolveReportedSuggestions.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveReportedSuggestions } from "./resolveReportedSuggestions.js";
+
+const mockReport = {
+	message: { primary: "", secondary: [], suggestions: [] },
+	range: {
+		begin: { column: 0, line: 1, raw: 0 },
+		end: { column: 3, line: 1, raw: 3 },
+	},
+};
+
+const mockTestCaseNormalized = {
+	code: "xyz",
+	fileName: "file.ts",
+	snapshot: "",
+};
+
+describe("resolveReportedSuggestions", () => {
+	it("returns undefined when reports is empty", () => {
+		const result = resolveReportedSuggestions([], mockTestCaseNormalized);
+
+		expect(result).toEqual(undefined);
+	});
+
+	it("returns undefined when given one report with no suggestions", () => {
+		const report = {
+			...mockReport,
+			suggestions: [],
+		};
+
+		const result = resolveReportedSuggestions([report], mockTestCaseNormalized);
+
+		expect(result).toEqual(undefined);
+	});
+
+	it("returns id and updated text when given a single file suggestion", () => {
+		const suggestion = {
+			id: "suggestion",
+			range: { begin: 0, end: 3 },
+			text: "abc",
+		};
+		const report = {
+			...mockReport,
+			suggestions: [suggestion],
+		};
+
+		const result = resolveReportedSuggestions([report], mockTestCaseNormalized);
+
+		expect(result).toEqual([
+			{
+				id: suggestion.id,
+				updated: suggestion.text,
+			},
+		]);
+	});
+
+	it("throws when given a test case with no suggestions", () => {
+		const report = {
+			...mockReport,
+			suggestions: [
+				{
+					files: {
+						"file.ts": () => [{ range: { begin: 0, end: 3 }, text: "def" }],
+					},
+					id: "suggestion-report",
+				},
+			],
+		};
+
+		const result = resolveReportedSuggestions([report], {
+			...mockTestCaseNormalized,
+			suggestions: undefined,
+		});
+
+		expect(() =>
+			resolveReportedSuggestions([report], {
+				...mockTestCaseNormalized,
+				suggestions: [
+					{
+						id: "suggestion-result",
+						updated: "...",
+					},
+				],
+			}),
+		).toThrowErrorMatchingInlineSnapshot(
+			`[Error: This test case describes suggestions across files, but the rule is only reporting changes to its own file.]`,
+		);
+	});
+
+	it("throws when given a test case that doesn't have cross-file suggestions", () => {
+		const report = {
+			...mockReport,
+			suggestions: [
+				{
+					files: {
+						"file.ts": () => [{ range: { begin: 0, end: 3 }, text: "def" }],
+					},
+					id: "suggestion-report",
+				},
+			],
+		};
+
+		expect(() =>
+			resolveReportedSuggestions([report], {
+				...mockTestCaseNormalized,
+				suggestions: [
+					{
+						id: "suggestion-result",
+						updated: "...",
+					},
+				],
+			}),
+		).toThrowErrorMatchingInlineSnapshot(
+			`[Error: This test case describes suggestions across files, but the rule is only reporting changes to its own file.]`,
+		);
+	});
+
+	it("returns id and a files object when given multi-file suggestions with a single file", () => {
+		const report = {
+			...mockReport,
+			suggestions: [
+				{
+					files: {
+						"file.ts": () => [{ range: { begin: 0, end: 3 }, text: "def" }],
+					},
+					id: "suggestion-report",
+				},
+			],
+		};
+
+		const result = resolveReportedSuggestions([report], {
+			...mockTestCaseNormalized,
+			suggestions: [
+				{
+					files: {
+						"file.ts": [{ original: "abc", updated: "def" }],
+					},
+					id: "suggestion-result",
+				},
+			],
+		});
+
+		expect(result).toEqual([
+			{
+				files: {
+					"file.ts": [
+						{
+							original: "abc",
+							updated: "def",
+						},
+					],
+				},
+				id: "suggestion-report",
+			},
+		]);
+	});
+
+	it("returns id and a files object when given multi-file suggestions with multiple file", () => {
+		const report = {
+			...mockReport,
+			suggestions: [
+				{
+					files: {
+						"fileA.ts": () => [{ range: { begin: 0, end: 5 }, text: "def-A" }],
+						"fileB.ts": () => [{ range: { begin: 0, end: 5 }, text: "def-B" }],
+					},
+					id: "suggestion-report",
+				},
+			],
+		};
+
+		const result = resolveReportedSuggestions([report], {
+			...mockTestCaseNormalized,
+			suggestions: [
+				{
+					files: {
+						"fileA.ts": [{ original: "abc-A", updated: "def-A" }],
+						"fileB.ts": [{ original: "abc-B", updated: "def-B" }],
+					},
+					id: "suggestion-result",
+				},
+			],
+		});
+
+		expect(result).toEqual([
+			{
+				files: {
+					"fileA.ts": [
+						{
+							original: "abc-A",
+							updated: "def-A",
+						},
+					],
+					"fileB.ts": [
+						{
+							original: "abc-B",
+							updated: "def-B",
+						},
+					],
+				},
+				id: "suggestion-report",
+			},
+		]);
+	});
+});

--- a/packages/rule-tester/src/types.ts
+++ b/packages/rule-tester/src/types.ts
@@ -29,14 +29,21 @@ export interface TestCase<
 	skip?: boolean;
 }
 
-export interface TestSuggestion {
-	files: Record<string, TestSuggestionFileCase[]>;
-	id: string;
-}
+export type TestSuggestion = TestSuggestionForFile | TestSuggestionForFiles;
 
 export interface TestSuggestionFileCase {
 	original: string;
 	updated: string;
+}
+
+export interface TestSuggestionForFile {
+	id: string;
+	updated: string;
+}
+
+export interface TestSuggestionForFiles {
+	files: Record<string, TestSuggestionFileCase[]>;
+	id: string;
 }
 
 export type ValidTestCase<Options extends object | undefined> =


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #361
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Changes the types and backing logic to allow a `TestSuggestionForFile` separately from `TestSuggestionForFiles`.

❤️‍🔥
